### PR TITLE
fix(cli) updates arg for openapi2kong and general CLI message

### DIFF
--- a/cmd/openapi2kong.go
+++ b/cmd/openapi2kong.go
@@ -14,9 +14,9 @@ import (
 
 // Executes the CLI command "openapi2kong"
 func execute(cmd *cobra.Command, args []string) {
-	inputFilename, err := cmd.Flags().GetString("state")
+	inputFilename, err := cmd.Flags().GetString("spec")
 	if err != nil {
-		log.Fatalf(fmt.Sprintf("failed getting cli argument 'state'; %%w"), err)
+		log.Fatalf(fmt.Sprintf("failed getting cli argument 'spec'; %%w"), err)
 	}
 
 	outputFilename, err := cmd.Flags().GetString("output-file")
@@ -85,7 +85,7 @@ See: https://github.com/Kong/kced/blob/main/docs/learnservice_oas.yaml`,
 
 func init() {
 	rootCmd.AddCommand(openapi2kongCmd)
-	openapi2kongCmd.Flags().StringP("state", "s", "-", "state file (OAS3, json/yaml) to process. Use - to read from stdin")
+	openapi2kongCmd.Flags().StringP("spec", "s", "-", "OpenAPI spec file to process. Use - to read from stdin")
 	openapi2kongCmd.Flags().StringP("output-file", "o", "-", "output file to write. Use - to write to stdout")
 	openapi2kongCmd.Flags().StringP("format", "", "yaml", "output format: json or yaml")
 	openapi2kongCmd.Flags().StringP("uuid-base", "", "",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,11 +12,10 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "kced",
-	Short: "A temporary CLI to test a new ApiOps implementation",
-	Long: `A temporary CLI to test a new ApiOps implementation.
+	Short: "A temporary CLI that drives the Kong go-apiops library",
+	Long: `A temporary CLI that drives the Kong go-apiops library.
 
-The ApiOps tooling will be enhanced, part of this effort is
-this tool, which is a rewrite of the Inso Openapi-2-Kong npm library.`,
+go-apiops houses an improved APIOps toolset for operating Kong Gateway deployments.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },


### PR DESCRIPTION
state is not an accurate description of incoming OAS files for the openapi2kong command.  Updated that to spec but kept the short argument the same.

Tidy up the general CLI usage text about kced and the librarys purpose