### PR TITLE
fix(oas2kong): revert accidental arg rename

### DIFF
--- a/cmd/openapi2kong.go
+++ b/cmd/openapi2kong.go
@@ -14,7 +14,7 @@ import (
 
 // Executes the CLI command "openapi2kong"
 func executeOpenapi2Kong(cmd *cobra.Command, _ []string) {
-	inputFilename, err := cmd.Flags().GetString("state")
+	inputFilename, err := cmd.Flags().GetString("spec")
 	if err != nil {
 		log.Fatalf(fmt.Sprintf("failed getting cli argument 'spec'; %%w"), err)
 	}


### PR DESCRIPTION
original commit: https://github.com/Kong/go-apiops/commit/1ab34b0874470a9bbde25086993303c499fb59df