### PR TITLE
feat(track): add info to track build history of file

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"log"
 
+	"github.com/kong/go-apiops/deckformat"
 	"github.com/kong/go-apiops/filebasics"
 	"github.com/kong/go-apiops/merge"
 	"github.com/spf13/cobra"
@@ -34,8 +35,15 @@ func executeMerge(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	trackInfo := deckformat.HistoryNewEntry("merge")
+	trackInfo["output"] = outputFilename
+
 	// do the work: read/merge
-	filebasics.MustWriteSerializedFile(outputFilename, merge.MustFiles(args), asYaml)
+	merged, info := merge.MustFiles(args)
+	trackInfo["files"] = info
+	deckformat.HistorySet(merged, nil, trackInfo)
+
+	filebasics.MustWriteSerializedFile(outputFilename, merged, asYaml)
 }
 
 //

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -35,13 +35,14 @@ func executeMerge(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	trackInfo := deckformat.HistoryNewEntry("merge")
-	trackInfo["output"] = outputFilename
-
 	// do the work: read/merge
 	merged, info := merge.MustFiles(args)
-	trackInfo["files"] = info
-	deckformat.HistorySet(merged, nil, trackInfo)
+
+	historyEntry := deckformat.HistoryNewEntry("merge")
+	historyEntry["output"] = outputFilename
+	historyEntry["files"] = info
+	deckformat.HistoryClear(merged)
+	deckformat.HistoryAppend(merged, historyEntry)
 
 	filebasics.MustWriteSerializedFile(outputFilename, merged, asYaml)
 }

--- a/cmd/openapi2kong.go
+++ b/cmd/openapi2kong.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/kong/go-apiops/convertoas3"
+	"github.com/kong/go-apiops/deckformat"
 	"github.com/kong/go-apiops/filebasics"
 	"github.com/spf13/cobra"
 )
@@ -61,8 +62,14 @@ func executeOpenapi2Kong(cmd *cobra.Command, _ []string) {
 		DocName: docName,
 	}
 
+	trackInfo := deckformat.HistoryNewEntry("openapi2kong")
+	trackInfo["input"] = inputFilename
+	trackInfo["output"] = outputFilename
+	trackInfo["uuid-base"] = docName
+
 	// do the work: read/convert/write
 	result := convertoas3.MustConvert(filebasics.MustReadFile(inputFilename), options)
+	deckformat.HistoryAppend(result, trackInfo)
 	filebasics.MustWriteSerializedFile(outputFilename, result, asYaml)
 }
 

--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"log"
 
+	"github.com/kong/go-apiops/deckformat"
 	"github.com/kong/go-apiops/filebasics"
 	"github.com/kong/go-apiops/patch"
 	"github.com/spf13/cobra"
@@ -60,8 +61,15 @@ func executePatch(cmd *cobra.Command, args []string) {
 		selector = s
 	}
 
+	trackInfo := deckformat.HistoryNewEntry("patch")
+	trackInfo["input"] = inputFilename
+	trackInfo["output"] = outputFilename
+	trackInfo["selector"] = selector
+	trackInfo["values"] = valuesMap
+
 	// do the work; read/patch/write
 	data := filebasics.MustDeserializeFile(inputFilename)
+	deckformat.HistoryAppend(data, trackInfo) // add before patching, so patch can operate on it
 	if len(valuesMap) > 0 {
 		// apply selector + value flags
 		data = patch.MustApplyValues(data, selector, valuesMap)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/kong/go-apiops/deckformat"
 	"github.com/spf13/cobra"
 )
 
@@ -25,5 +26,6 @@ commit hash of the source tree.`,
 }
 
 func init() {
+	deckformat.ToolVersionSet("kceD", VERSION, COMMIT)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/convertoas3/oas3.go
+++ b/convertoas3/oas3.go
@@ -239,7 +239,7 @@ func getPluginsList(
 	if pluginsToInclude != nil {
 		for _, config := range *pluginsToInclude {
 			pluginName := (*config)["name"].(string) // safe because it was previously parsed
-			configCopy := *(jsonbasics.DeepCopy(config))
+			configCopy := *(jsonbasics.DeepCopyObject(config))
 
 			// generate a new ID, for a new plugin, based on new basename
 			configCopy["id"] = createPluginID(uuidNamespace, baseName, configCopy)

--- a/deckformat/deckformat_test.go
+++ b/deckformat/deckformat_test.go
@@ -1,27 +1,286 @@
 package deckformat_test
 
 import (
+	. "github.com/kong/go-apiops/deckformat"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("deckformat", func() {
-	Describe("CompatibleTransform", func() {
-		PIt("still to do", func() {
-		})
-	})
-
-	Describe("CompatibleVersion", func() {
-		PIt("still to do", func() {
-		})
-	})
-
-	Describe("CompatibleFile", func() {
-		PIt("still to do", func() {
-		})
-	})
-
 	Describe("ParseFormatVersion", func() {
-		PIt("still to do", func() {
+		It("parses a version", func() {
+			data := map[string]interface{}{
+				VersionKey: "123.456",
+			}
+
+			major, minor, err := ParseFormatVersion(data)
+			Expect(major).To(Equal(123))
+			Expect(minor).To(Equal(456))
+			Expect(err).To(BeNil())
+		})
+
+		It("returns minor = 0 if omitted", func() {
+			data := map[string]interface{}{
+				VersionKey: "123",
+			}
+
+			major, minor, err := ParseFormatVersion(data)
+			Expect(major).To(Equal(123))
+			Expect(minor).To(Equal(0))
+			Expect(err).To(BeNil())
+		})
+
+		Describe("returns an error if the version", func() {
+			It("has more than 2 segments", func() {
+				data := map[string]interface{}{
+					VersionKey: "123.456.789",
+				}
+
+				major, minor, err := ParseFormatVersion(data)
+				Expect(err).To(MatchError("expected field '._format_version' to be a string in 'x.y' format"))
+				Expect(major).To(Equal(0))
+				Expect(minor).To(Equal(0))
+			})
+
+			It("has a non-numeric major", func() {
+				data := map[string]interface{}{
+					VersionKey: "abc.456",
+				}
+
+				major, minor, err := ParseFormatVersion(data)
+				Expect(err).To(MatchError("expected field '._format_version' to be a string in 'x.y' format"))
+				Expect(major).To(Equal(0))
+				Expect(minor).To(Equal(0))
+			})
+
+			It("has a non-numeric minor", func() {
+				data := map[string]interface{}{
+					VersionKey: "123.def",
+				}
+
+				major, minor, err := ParseFormatVersion(data)
+				Expect(err).To(MatchError("expected field '._format_version' to be a string in 'x.y' format"))
+				Expect(major).To(Equal(0))
+				Expect(minor).To(Equal(0))
+			})
+
+			It("doesn't exist", func() {
+				data := map[string]interface{}{}
+
+				major, minor, err := ParseFormatVersion(data)
+				Expect(err).To(MatchError("expected field '._format_version' to be a string in 'x.y' format"))
+				Expect(major).To(Equal(0))
+				Expect(minor).To(Equal(0))
+			})
+
+			It("doesn't exist, because data is nil", func() {
+				major, minor, err := ParseFormatVersion(nil)
+				Expect(err).To(MatchError("expected field '._format_version' to be a string in 'x.y' format"))
+				Expect(major).To(Equal(0))
+				Expect(minor).To(Equal(0))
+			})
+		})
+	})
+
+	Describe("application version", func() {
+		It("ToolVersionSet/Get/String", func() {
+			ToolVersionSet("my-name", "1.2.3", "commit-xyz")
+
+			n, v, c := ToolVersionGet()
+			Expect(n).To(BeIdenticalTo("my-name"))
+			Expect(v).To(BeIdenticalTo("1.2.3"))
+			Expect(c).To(BeIdenticalTo("commit-xyz"))
+
+			Expect(ToolVersionString()).Should(Equal("my-name 1.2.3 (commit-xyz)"))
+
+			Expect(func() {
+				ToolVersionSet("another name", "1.2.3", "commit-xyz")
+			}).Should(Panic())
+		})
+	})
+
+	Describe("compatibility", func() {
+		DescribeTable("CompatibleTransform",
+			func(transform1 interface{}, transform2 interface{}, expected bool) {
+				res := CompatibleTransform(
+					map[string]interface{}{TransformKey: transform1},
+					map[string]interface{}{TransformKey: transform2},
+				)
+				if expected {
+					// compatible, then result is nil
+					Expect(res).To(BeNil())
+				} else {
+					// not-compatible, then result is an error
+					Expect(res).Should(HaveOccurred())
+				}
+			},
+			// transform1, transform2, expected
+			Entry("1", true, false, false),
+			Entry("2", true, true, true),
+			Entry("3", true, nil, true),
+			Entry("4", false, false, true),
+			Entry("5", false, true, false),
+			Entry("6", false, nil, false),
+			Entry("7", nil, false, false),
+			Entry("8", nil, true, true),
+			Entry("9", nil, nil, true),
+		)
+
+		DescribeTable("CompatibleVersion",
+			func(version1 interface{}, version2 interface{}, expected bool) {
+				res := CompatibleVersion(
+					map[string]interface{}{VersionKey: version1},
+					map[string]interface{}{VersionKey: version2},
+				)
+				if expected {
+					// compatible, then result is nil
+					Expect(res).To(BeNil())
+				} else {
+					// not-compatible, then result is an error
+					Expect(res).Should(HaveOccurred())
+				}
+			},
+			// version1, version2, expected
+			Entry("same major is compatible", "1.1", "1.2", true),
+			Entry("different major is incompatible", "1.1", "2.1", false),
+			Entry("omitted version is compatible 1", "1.1", nil, true),
+			Entry("omitted version is compatible 2", nil, "1.1", true),
+			Entry("omitted version is compatible 3", nil, nil, true),
+			Entry("bad version is incompatible 1", "bad", "1.1", false),
+			Entry("bad version is incompatible 2", "bad", nil, false),
+			Entry("bad version is incompatible 3", "1.1", "bad", false),
+			Entry("bad version is incompatible 4", nil, "bad", false),
+		)
+
+		DescribeTable("CompatibleFile",
+			func(version1 interface{}, transform1 interface{}, version2 interface{}, transform2 interface{}, expected bool) {
+				res := CompatibleFile(
+					map[string]interface{}{
+						VersionKey:   version1,
+						TransformKey: transform1,
+					},
+					map[string]interface{}{
+						VersionKey:   version2,
+						TransformKey: transform2,
+					},
+				)
+				if expected {
+					// compatible, then result is nil
+					Expect(res).To(BeNil())
+				} else {
+					// not-compatible, then result is an error
+					Expect(res).Should(HaveOccurred())
+				}
+			},
+			// version1, version2, expected
+			Entry("1", "1.1", true, "1.2", true, true),
+			Entry("2", "1.1", true, "1.2", false, false),
+			Entry("3", "1.1", true, "2.1", true, false),
+		)
+	})
+
+	Describe("history", func() {
+		It("the key is set to '_ignore'", func() {
+			Expect(HistoryKey).To(Equal("_ignore"))
+		})
+
+		Describe("HistoryGet", func() {
+			It("returns the history array", func() {
+				hist := []interface{}{"one", "two"}
+				data := map[string]interface{}{
+					HistoryKey: hist,
+				}
+				res := HistoryGet(data)
+
+				Expect(res).To(BeEquivalentTo(hist))
+			})
+
+			It("returns an empty array if none found", func() {
+				res := HistoryGet(map[string]interface{}{})
+				Expect(res).To(BeEquivalentTo([]interface{}{}))
+			})
+
+			It("returns an empty array if data-in is nil", func() {
+				res := HistoryGet(nil)
+				Expect(res).To(BeEquivalentTo([]interface{}{}))
+			})
+
+			It("appends the existing history entry if it's not an array", func() {
+				data := map[string]interface{}{
+					HistoryKey: "foobar",
+				}
+				res := HistoryGet(data)
+				Expect(res).To(BeEquivalentTo([]interface{}{"foobar"}))
+			})
+		})
+
+		It("HistoryNewEntry creates a new entry", func() {
+			// ToolVersionSet("my-name", "1.2.3", "commit-xyz")
+			cmd := "myCmd"
+			entry := HistoryNewEntry(cmd)
+
+			Expect(entry).To(BeEquivalentTo(map[string]interface{}{
+				"command": cmd,
+				"version": ToolVersionString(),
+			}))
+		})
+
+		Describe("HistorySet", func() {
+			It("sets the history array", func() {
+				hist := []interface{}{"one", "two"}
+				data := map[string]interface{}{}
+
+				HistorySet(data, hist)
+				res := data[HistoryKey].([]interface{})
+				Expect(res).To(BeEquivalentTo(hist))
+			})
+
+			It("deletes history-array if nil", func() {
+				data := map[string]interface{}{
+					HistoryKey: "delete me",
+				}
+				HistorySet(data, nil)
+
+				res, found := data[HistoryKey]
+				Expect(res).To(BeNil())
+				Expect(found).To(BeFalse())
+			})
+		})
+
+		Describe("HistoryAppend", func() {
+			It("adds an entry to an existing array", func() {
+				hist := []interface{}{"one", "two"}
+				data := map[string]interface{}{
+					HistoryKey: hist,
+				}
+				HistoryAppend(data, "three")
+				res := HistoryGet(data)
+
+				Expect(res).To(BeEquivalentTo([]interface{}{"one", "two", "three"}))
+			})
+
+			It("creates an array if it doesn't exist", func() {
+				data := map[string]interface{}{}
+
+				HistoryAppend(data, "one")
+
+				res := HistoryGet(data)
+				Expect(res).To(BeEquivalentTo([]interface{}{"one"}))
+			})
+		})
+
+		Describe("HistoryClear", func() {
+			It("clears the history key", func() {
+				data := map[string]interface{}{
+					HistoryKey: "delete me",
+				}
+
+				HistoryClear(data)
+
+				res, found := data[HistoryKey]
+				Expect(res).To(BeNil())
+				Expect(found).To(BeFalse())
+			})
 		})
 	})
 })

--- a/jsonbasics/jsonbasics.go
+++ b/jsonbasics/jsonbasics.go
@@ -153,7 +153,7 @@ func DeepCopyObject(data *map[string]interface{}) *map[string]interface{} {
 }
 
 // DeepCopyArray implements a poor man's deepcopy by jsonify/de-jsonify
-func DeepCopyarray(data *[]interface{}) *[]interface{} {
+func DeepCopyArray(data *[]interface{}) *[]interface{} {
 	var dataCopy []interface{}
 	serialized, _ := json.Marshal(data)
 	_ = json.Unmarshal(serialized, &dataCopy)

--- a/jsonbasics/jsonbasics.go
+++ b/jsonbasics/jsonbasics.go
@@ -144,9 +144,17 @@ func GetBoolIndex(arr []interface{}, index int) (bool, error) {
 	return false, fmt.Errorf("expected index '%d' to be a boolean", index)
 }
 
-// DeepCopy implements a poor man's deepcopy by jsonify/de-jsonify
-func DeepCopy(data *map[string]interface{}) *map[string]interface{} {
+// DeepCopyObject implements a poor man's deepcopy by jsonify/de-jsonify
+func DeepCopyObject(data *map[string]interface{}) *map[string]interface{} {
 	var dataCopy map[string]interface{}
+	serialized, _ := json.Marshal(data)
+	_ = json.Unmarshal(serialized, &dataCopy)
+	return &dataCopy
+}
+
+// DeepCopyArray implements a poor man's deepcopy by jsonify/de-jsonify
+func DeepCopyarray(data *[]interface{}) *[]interface{} {
+	var dataCopy []interface{}
 	serialized, _ := json.Marshal(data)
 	_ = json.Unmarshal(serialized, &dataCopy)
 	return &dataCopy

--- a/jsonbasics/jsonbasics_test.go
+++ b/jsonbasics/jsonbasics_test.go
@@ -158,7 +158,12 @@ var _ = Describe("jsonbasics", func() {
 		})
 	})
 
-	Describe("DeepCopy", func() {
+	Describe("DeepCopyObject", func() {
+		PIt("still to do", func() {
+		})
+	})
+
+	Describe("DeepCopyArray", func() {
 		PIt("still to do", func() {
 		})
 	})

--- a/merge/merge.go
+++ b/merge/merge.go
@@ -74,7 +74,7 @@ func Files(filenames []string) (map[string]interface{}, []interface{}, error) {
 		newInfo := make(map[string]interface{})
 		newInfo["filename"] = filename
 		fileHistory := deckformat.HistoryGet(data)
-		if len(*fileHistory) > 0 {
+		if len(fileHistory) > 0 {
 			newInfo["info"] = fileHistory
 		}
 		historyArray[i] = newInfo

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 var _ = Describe("Merge", func() {
-	validateMerge := func(filenames []string, expected string, expectError bool) {
+	validateMerge := func(filenames []string, expected string, expectError bool, expectedHistory []interface{}) {
 		GinkgoHelper()
-		res, err := merge.Files(filenames)
+		res, hist, err := merge.Files(filenames)
 		if err != nil {
 			if expectError {
 				// 'expected' is an error string to match
@@ -38,6 +38,8 @@ var _ = Describe("Merge", func() {
 				Expect(*result).To(MatchJSON(*expectedResult))
 			}
 		}
+
+		Expect(hist).To(BeEquivalentTo(expectedHistory))
 	}
 
 	Describe("merges files", func() {
@@ -51,8 +53,19 @@ var _ = Describe("Merge", func() {
 			}
 			expected := "test1_expected.json"
 			expectErr := false
+			expectedHist := []interface{}{
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file1.yml",
+				},
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file2.yml",
+				},
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file3.yml",
+				},
+			}
 
-			validateMerge(fileList, expected, expectErr)
+			validateMerge(fileList, expected, expectErr, expectedHist)
 		})
 
 		It("attempt 2: same files, different order", func() {
@@ -65,8 +78,19 @@ var _ = Describe("Merge", func() {
 			}
 			expected := "test2_expected.json"
 			expectErr := false
+			expectedHist := []interface{}{
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file3.yml",
+				},
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file2.yml",
+				},
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file1.yml",
+				},
+			}
 
-			validateMerge(fileList, expected, expectErr)
+			validateMerge(fileList, expected, expectErr, expectedHist)
 		})
 
 		It("with incompatible versions errors", func() {
@@ -78,7 +102,7 @@ var _ = Describe("Merge", func() {
 				"major versions are incompatible; 3.0 and 1.0"
 			expectErr := true
 
-			validateMerge(fileList, expected, expectErr)
+			validateMerge(fileList, expected, expectErr, nil)
 		})
 
 		It("with incompatible '_transform' errors", func() {
@@ -90,7 +114,7 @@ var _ = Describe("Merge", func() {
 				"files with '_transform: true' (default) and '_transform: false' are not compatible"
 			expectErr := true
 
-			validateMerge(fileList, expected, expectErr)
+			validateMerge(fileList, expected, expectErr, nil)
 		})
 	})
 })


### PR DESCRIPTION
This records actions taken in the `_ignore` array of the file. This key is being ignored in the decK file format, hence safe to use.

It's not obvious however and potentially can get mixed with other items added by users in that array. Hence the preference is to move the history array to a new top-level field `_history`, but that would require changes to Kong and decK to ensure they ignore the field.

Todo:

- [x] add tests
- [ ] optional; add a cli command to add info to the array if another tool is used to update (eg. a modification using `jq`)