### PR TITLE
feat(namespace): add namespacing paths

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,0 +1,124 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"log"
+	"strings"
+
+	"github.com/kong/go-apiops/deckformat"
+	"github.com/kong/go-apiops/filebasics"
+	"github.com/kong/go-apiops/namespace"
+	"github.com/kong/go-apiops/patch"
+	"github.com/spf13/cobra"
+)
+
+// Executes the CLI command "namespace"
+func executeNamespace(cmd *cobra.Command, _ []string) {
+	inputFilename, err := cmd.Flags().GetString("state")
+	if err != nil {
+		log.Fatalf("failed getting cli argument 'state'; %s", err)
+	}
+
+	outputFilename, err := cmd.Flags().GetString("output-file")
+	if err != nil {
+		log.Fatalf("failed getting cli argument 'output-file'; %s", err)
+	}
+
+	var asYaml bool
+	{
+		outputFormat, err := cmd.Flags().GetString("format")
+		if err != nil {
+			log.Fatalf("failed getting cli argument 'format'; %s", err)
+		}
+		if outputFormat == outputFormatYaml {
+			asYaml = true
+		} else if outputFormat == outputFormatJSON {
+			asYaml = false
+		} else {
+			log.Fatalf("expected '--format' to be either '"+outputFormatYaml+
+				"' or '"+outputFormatJSON+"', got: '%s'", outputFormat)
+		}
+	}
+
+	var matchPrefix string
+	{
+		matchPrefix, err := cmd.Flags().GetString("prefix")
+		if err != nil {
+			log.Fatalf("failed to retrieve '--prefix' value; %s", err)
+		}
+		if !(strings.HasPrefix(matchPrefix, "/") || strings.HasPrefix(matchPrefix, "~/")) {
+			log.Fatalf("invalid prefix; the prefix MUST start with '/', got: '%s'", matchPrefix)
+		}
+	}
+
+	var namespaceStr string
+	{
+		namespace, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			log.Fatalf("failed to retrieve '--namespace' value; %s", err)
+		}
+		if !strings.HasPrefix(namespace, "/") {
+			log.Fatalf("invalid namespace; the namepsace MUST start with '/', got: '%s'", namespace)
+		}
+	}
+
+	trackInfo := deckformat.HistoryNewEntry("namespace")
+	trackInfo["input"] = inputFilename
+	trackInfo["output"] = outputFilename
+	trackInfo["prefix"] = matchPrefix
+	trackInfo["namespace"] = namespaceStr
+
+	// do the work; read/patch/write
+	data := filebasics.MustDeserializeFile(inputFilename)
+	deckformat.HistoryAppend(data, trackInfo) // add before patching, so patch can operate on it
+
+	yamlNode := patch.ConvertToYamlNode(data)
+
+	err = namespace.Apply(yamlNode, matchPrefix, namespaceStr)
+	if err != nil {
+		log.Fatalf("failed to apply the namespace: %s", err)
+	}
+
+	data = patch.ConvertToJSONobject(yamlNode)
+
+	filebasics.MustWriteSerializedFile(outputFilename, data, asYaml)
+}
+
+//
+//
+// Define the CLI data for the namespace command
+//
+//
+
+var namespaceCmd = &cobra.Command{
+	Use:   "namespace [flags]",
+	Short: "Namespaces API paths by prefixing it",
+	Long: `Namespaces API paths by prefixing it.
+
+By prefixing paths with a specific segment, colliding paths to services can be
+namespaced to prevent the collisions. Eg. 2 API definitions that both expose a
+'/list' path. By prefixing one with '/addressbook' and the other with '/cookbook'
+the resulting paths '/addressbook/list' and '/cookbook/list' can be exposed without
+colliding.
+
+'strip-path' settings will be added to the route-config to ensure it is stripped
+again from the path before sending it upstream.
+
+NOTE: all paths within a route must match for the route to be updated.
+`,
+	Args: cobra.NoArgs,
+	Run:  executeNamespace,
+}
+
+func init() {
+	rootCmd.AddCommand(namespaceCmd)
+	namespaceCmd.Flags().StringP("state", "s", "-", "decK file to process. Use - to read from stdin.")
+	namespaceCmd.Flags().StringP("output-file", "o", "-", "output file to write. Use - to write to stdout.")
+	namespaceCmd.Flags().StringP("format", "", outputFormatYaml, "output format: "+outputFormatJSON+
+		" or "+outputFormatYaml)
+	namespaceCmd.Flags().StringP("prefix", "", "/", "the existing path-prefix to match. Only matching paths "+
+		"will be namespaced (plain or regex based)")
+	namespaceCmd.Flags().StringP("namespace", "", "", "the namespace to apply")
+}

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -1,0 +1,143 @@
+package namespace
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
+	"gopkg.in/yaml.v3"
+)
+
+// Apply updates all route entities found within the yamlNode with the namespace.
+func Apply(data *yaml.Node, prefix string, namespaceStr string) error {
+	if !(strings.HasPrefix(prefix, "/") || strings.HasPrefix(prefix, "~/")) {
+		panic(fmt.Sprintf("invalid prefix; the prefix MUST start with '/', got: '%s'", prefix))
+	}
+
+	if !strings.HasPrefix(namespaceStr, "/") {
+		panic(fmt.Sprintf("invalid namespace; the namespace MUST start with '/', got: '%s'", prefix))
+	}
+
+	query, err := yamlpath.NewPath("$..routes[*]")
+	if err != nil {
+		panic("failed compiling route selector")
+	}
+
+	allRoutes, err := query.Find(data)
+	if err != nil {
+		return errors.New("failed to collect routes from the input data")
+	}
+
+	for _, route := range allRoutes {
+		if route.Kind == yaml.MappingNode {
+			UpdateRoute(route, prefix, namespaceStr)
+		}
+	}
+
+	return nil
+}
+
+// UpdateRoute update a single route object with the namespace.
+func UpdateRoute(route *yaml.Node, prefix string, ns string) {
+	if route.Kind != yaml.MappingNode {
+		panic("expected a MappingNode")
+	}
+
+	var updated bool
+	for i := 0; i < len(route.Content); {
+		key := route.Content[i]
+		if key.Value == "paths" {
+			// found the 'paths' property
+			value := route.Content[i+1]
+			if value.Kind == yaml.SequenceNode {
+				// it's an array, as expected, go update it
+				updated = updatePathsArray(value, prefix, ns)
+				break
+			}
+		}
+		i = i + 2
+	}
+
+	if !updated {
+		return // nothing changed, so we're done
+	}
+
+	// set strip_path properties
+	stripPathDone := false
+	stripPathPrefixDone := false
+
+	// update strip_path properties if they exist
+	for i := 0; i < len(route.Content); {
+		key := route.Content[i]
+		if key.Value == "strip_path" {
+			route.Content[i+1].Value = "true"
+			stripPathDone = true
+		}
+		if key.Value == "strip_prefix" {
+			route.Content[i+1].Value = ns + route.Content[i+1].Value
+			stripPathPrefixDone = true
+		}
+		i = i + 2
+	}
+
+	// add strip_path properties if they didn't exist
+	if !stripPathDone {
+		keyNode := yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Style: yaml.DoubleQuotedStyle,
+			Tag:   "!!str",
+			Value: "strip_path",
+		}
+		valueNode := yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!bool",
+			Value: "true",
+		}
+		route.Content = append(route.Content, &keyNode, &valueNode)
+	}
+	if !stripPathPrefixDone {
+		keyNode := yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Style: yaml.DoubleQuotedStyle,
+			Tag:   "!!str",
+			Value: "strip_prefix",
+		}
+		valueNode := yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Style: yaml.DoubleQuotedStyle,
+			Tag:   "!!str",
+			Value: ns,
+		}
+		route.Content = append(route.Content, &keyNode, &valueNode)
+	}
+}
+
+// updatePathsArray updates a paths array of a route-entity. Returns true if the
+// route was updated.
+func updatePathsArray(paths *yaml.Node, prefix string, ns string) bool {
+	if paths.Kind != yaml.SequenceNode {
+		panic("expected a SequenceNode")
+	}
+
+	for _, path := range paths.Content {
+		if path.Kind != yaml.ScalarNode {
+			return false // only dealing with scalar values; path strings
+		}
+
+		if !(strings.HasPrefix(path.Value, prefix) || strings.HasPrefix(path.Value, "~"+prefix)) {
+			return false // prefix has no match, but all paths must match...
+		}
+	}
+
+	// all path enties patch, so now update them
+	for _, path := range paths.Content {
+		if strings.HasPrefix(path.Value, "~") {
+			// path is a regex, so insert prefix after the "~"
+			path.Value = strings.Replace(path.Value, "~", "~"+ns, 1)
+		} else {
+			path.Value = ns + path.Value
+		}
+	}
+	return true
+}

--- a/namespace/namespace_suite_test.go
+++ b/namespace/namespace_suite_test.go
@@ -1,0 +1,13 @@
+package namespace_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNamespace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Namespace Suite")
+}

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -64,6 +64,27 @@ var _ = Describe("Namespace", func() {
 			}`))
 		})
 
+		It("doesn't set 'strip_prefix' if 'strip_path' was already set", func() {
+			data := `{
+				"paths": [
+					"/one",
+					"/two"
+				],
+				"strip_path": true
+			}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(`{
+				"paths": [
+					"/prefix/one",
+					"/prefix/two"
+				],
+				"strip_path": true
+			}`))
+		})
+
 		It("keeps stripping existing prefixes (plain)", func() {
 			data := `{
 				"paths": [

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -1,0 +1,192 @@
+package namespace_test
+
+import (
+	"github.com/kong/go-apiops/namespace"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+func toYaml(data string) *yaml.Node {
+	var yNode yaml.Node
+	err := yaml.Unmarshal([]byte(data), &yNode)
+	if err != nil {
+		panic(err)
+	}
+	return yNode.Content[0] // first entry is the node, yNode is the document
+}
+
+func toString(data *yaml.Node) string {
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+var _ = Describe("Namespace", func() {
+	Describe("UpdateRoute", func() {
+		It("updates plain paths", func() {
+			data := `{ "paths": [
+				"/one",
+				"/two"
+			]}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(`{
+				"paths": [
+					"/prefix/one",
+					"/prefix/two"
+				],
+				"strip_path": true,
+				"strip_prefix": "/prefix"
+			}`))
+		})
+
+		It("updates regex paths", func() {
+			data := `{ "paths": [
+				"~/one$",
+				"~/two$"
+			]}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(`{
+				"paths": [
+					"~/prefix/one$",
+					"~/prefix/two$"
+				],
+				"strip_path": true,
+				"strip_prefix": "/prefix"
+			}`))
+		})
+
+		It("keeps stripping existing prefixes (plain)", func() {
+			data := `{
+				"paths": [
+					"/xyz/one",
+					"/xyz/two"
+				],
+				"strip_prefix": "/xyz"
+			}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(`{
+				"paths": [
+					"/prefix/xyz/one",
+					"/prefix/xyz/two"
+				],
+				"strip_path": true,
+				"strip_prefix": "/prefix/xyz"
+			}`))
+		})
+
+		It("keeps stripping existing prefixes (regex)", func() {
+			data := `{
+				"paths": [
+					"~/xyz/one$",
+					"~/xyz/two$"
+				],
+				"strip_prefix": "/xyz"
+			}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(`{
+				"paths": [
+					"~/prefix/xyz/one$",
+					"~/prefix/xyz/two$"
+				],
+				"strip_path": true,
+				"strip_prefix": "/prefix/xyz"
+			}`))
+		})
+
+		It("skips routes where not all paths entries match", func() {
+			data := `{ "paths": [
+				"/one",
+				"/two"
+			]}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/one", "/prefix") // matches only "/one"
+
+			Expect(toString(route)).To(MatchJSON(data))
+		})
+
+		It("skips routes with non-scalar paths-entries", func() {
+			data := `{ "paths": [
+				"/one",
+				"/two",
+				{ "this": "is an object" }
+			]}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(data))
+		})
+
+		It("skips routes with paths as a non-array", func() {
+			data := `{ "paths": {}}`
+
+			route := toYaml(data)
+			namespace.UpdateRoute(route, "/", "/prefix")
+
+			Expect(toString(route)).To(MatchJSON(data))
+		})
+	})
+
+	Describe("Apply", func() {
+		It("handles all routes in a yamlNode", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "route1",
+						"paths": [
+							"/one",
+							"/two"
+						]
+					},{
+						"name": "route2",
+						"paths": [
+							"~/xyz/one$",
+							"~/xyz/two$"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "/", "/prefix")
+
+			Expect(toString(config)).To(MatchJSON(`{
+				"routes": [
+					{
+						"name": "route1",
+						"paths": [
+							"/prefix/one",
+							"/prefix/two"
+						],
+						"strip_path": true,
+						"strip_prefix": "/prefix"
+					},{
+						"name": "route2",
+						"paths": [
+							"~/prefix/xyz/one$",
+							"~/prefix/xyz/two$"
+						],
+						"strip_path": true,
+						"strip_prefix": "/prefix"
+					}
+				]
+			}`))
+		})
+	})
+})


### PR DESCRIPTION
Adds a new command "namespace" to namespace API paths

```
$ ./kced namespace --help
Namespaces API paths by prefixing it.

By prefixing paths with a specific segment, colliding paths to services can be
namespaced to prevent the colissions. Eg. 2 API definitions that both expose a
'/list' path. By prefixing one with '/addressbook' and the other with '/cookbook'
the resulting paths '/addressbook/list' and '/cookbook/list' can be exposed without
colliding.

'strip-path' settings will be added to the route-config to ensure it is stripped
again from the path before sending it upstream.

NOTE: all paths within a route must match for the route to be updated.

Usage:
  kced namespace [flags]

Flags:
      --format string        output format: json or yaml (default "yaml")
  -h, --help                 help for namespace
      --namespace string     the namespace or updated prefix to apply
  -o, --output-file string   output file to write. Use - to write to stdout. (default "-")
  -p, --prefix string        the existing path-prefix to match. Only matching paths will be namespaced (plain or regex based) (default "/")
  -s, --state string         decK file to process. Use - to read from stdin. (default "-")

$
```

Example

using the following file, and this command:

`cat input.yml | ./kced namespace --prefix=/list --namespace=/addressbook > output.yml`

File `input.yml`:
```yaml
_format_version: "3.0"
services:
- name: example-service
  url: http://example.com
  routes:
  - name: example-route
    paths:
    - /list
    - ~/list/(?<id>[^/]+)$
```

Resulting `output.yml`:
```yaml
_format_version: "3.0"
services:
- name: example-service
  url: http://example.com
  routes:
  - name: example-route
    paths:
    - /addressbook/list
    - ~/addressbook/list/(?<id>[^/]+)$
    strip_path: true
    strip_prefix: /addressbook
```

This relies on a Kong feature not yet implemented; a `strip_prefix` setting, see https://konghq.atlassian.net/browse/FTI-2302