### PR TITLE
chore(history): temporary disable history recording

### DIFF
--- a/deckformat/deckformat.go
+++ b/deckformat/deckformat.go
@@ -208,6 +208,9 @@ func HistorySet(filedata map[string]interface{}, historyArray []interface{}) {
 		return
 	}
 	filedata[HistoryKey] = historyArray
+
+	// TODO: remove this after the we get support for metafields in deck
+	HistoryClear(filedata)
 }
 
 // HistoryAppend appends an entry (if non-nil) to the history info array. If there is

--- a/deckformat/deckformat_test.go
+++ b/deckformat/deckformat_test.go
@@ -226,7 +226,7 @@ var _ = Describe("deckformat", func() {
 		})
 
 		Describe("HistorySet", func() {
-			It("sets the history array", func() {
+			PIt("sets the history array", func() {
 				hist := []interface{}{"one", "two"}
 				data := map[string]interface{}{}
 
@@ -247,7 +247,7 @@ var _ = Describe("deckformat", func() {
 			})
 		})
 
-		Describe("HistoryAppend", func() {
+		PDescribe("HistoryAppend", func() {
 			It("adds an entry to an existing array", func() {
 				hist := []interface{}{"one", "two"}
 				data := map[string]interface{}{


### PR DESCRIPTION
deck doesn't support the `_ignore` and `_comment` fields