### PR TITLE
feat(jsonbasics): function to set an array of objects

### DIFF
--- a/jsonbasics/jsonbasics.go
+++ b/jsonbasics/jsonbasics.go
@@ -52,6 +52,22 @@ func GetObjectArrayField(object map[string]interface{}, fieldName string) ([]map
 	return result, nil
 }
 
+// SetObjectArrayField sets an array in a parsed json object. This ensure it is of type
+// []interface{}, such that a next call to GetObjectArrayField will work.
+// If 'objectArray' is nil, then the field is deleted from the object.
+func SetObjectArrayField(object map[string]interface{}, fieldName string, objectArray []map[string]interface{}) {
+	if objectArray == nil {
+		delete(object, fieldName)
+		return
+	}
+
+	arr := make([]interface{}, len(objectArray))
+	for i, obj := range objectArray {
+		arr[i] = obj
+	}
+	object[fieldName] = arr
+}
+
 // GetStringArrayField returns a new slice containing all strings from the array referenced by fieldName.
 // If the field is not an array, it returns an error.
 // If the field doesn't exist it returns an empty array.

--- a/jsonbasics/jsonbasics_test.go
+++ b/jsonbasics/jsonbasics_test.go
@@ -133,6 +133,39 @@ var _ = Describe("jsonbasics", func() {
 		})
 	})
 
+	Describe("SetObjectArrayField", func() {
+		It("sets an array to be recognized as an array again", func() {
+			data := []byte(`{
+				"myArray": [
+					{ "name": "one" }
+				]
+			}`)
+			obj := MustDeserialize(&data)
+			objArr, err := GetObjectArrayField(obj, "myArray")
+			Expect(err).To(BeNil())
+			Expect(objArr[0]["name"]).To(Equal("one"))
+
+			// append a new entry and set it in the object
+			entry := make(map[string]interface{})
+			entry["name"] = "two"
+			obj["myArray"] = append(objArr, entry)
+
+			// since the myArray field is now []map[string]interface{} instead of
+			// []interface{} it will no longer be recognized as an array
+			objArr2, err := GetObjectArrayField(obj, "myArray")
+			Expect(err.Error()).To(ContainSubstring("not an array"))
+			Expect(objArr2).To(BeNil())
+
+			// Do it again, but use the SetObjectArrayField
+			SetObjectArrayField(obj, "myArray", append(objArr, entry))
+			// check that it worked
+			objArr3, err := GetObjectArrayField(obj, "myArray")
+			Expect(err).To(BeNil())
+			Expect(objArr3[0]["name"]).To(Equal("one"))
+			Expect(objArr3[1]["name"]).To(Equal("two"))
+		})
+	})
+
 	Describe("RemoveObjectFromArrayByFieldValue", func() {
 		PIt("still to do", func() {
 		})


### PR DESCRIPTION
The array must be set as `[]interface{}` to be recognized in the next `GetObjectArryField` call.