### PR TITLE
fix(filebasics): implement constants for formats

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/kong/go-apiops/deckformat"
 	"github.com/kong/go-apiops/filebasics"
@@ -24,20 +25,13 @@ func executeMerge(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed getting cli argument 'output-file'; %w", err)
 	}
 
-	var asYaml bool
+	var outputFormat string
 	{
-		outputFormat, err := cmd.Flags().GetString("format")
+		outputFormat, err = cmd.Flags().GetString("format")
 		if err != nil {
 			return fmt.Errorf("failed getting cli argument 'format'; %w", err)
 		}
-		if outputFormat == outputFormatYaml {
-			asYaml = true
-		} else if outputFormat == outputFormatJSON {
-			asYaml = false
-		} else {
-			return fmt.Errorf("expected '--format' to be either '%s' or '%s', got: '%s'",
-				outputFormatYaml, outputFormatJSON, outputFormat)
-		}
+		outputFormat = strings.ToUpper(outputFormat)
 	}
 
 	// do the work: read/merge
@@ -52,7 +46,7 @@ func executeMerge(cmd *cobra.Command, args []string) error {
 	deckformat.HistoryClear(merged)
 	deckformat.HistoryAppend(merged, historyEntry)
 
-	return filebasics.WriteSerializedFile(outputFilename, merged, asYaml)
+	return filebasics.WriteSerializedFile(outputFilename, merged, outputFormat)
 }
 
 //
@@ -79,5 +73,6 @@ determined by the '_transform' and '_format_version' fields.`,
 func init() {
 	rootCmd.AddCommand(mergeCmd)
 	mergeCmd.Flags().StringP("output-file", "o", "-", "output file to write. Use - to write to stdout")
-	mergeCmd.Flags().StringP("format", "", outputFormatYaml, "output format: "+outputFormatJSON+" or "+outputFormatYaml)
+	mergeCmd.Flags().StringP("format", "", filebasics.OutputFormatYaml, "output format: "+
+		filebasics.OutputFormatJSON+" or "+filebasics.OutputFormatYaml)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,11 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	outputFormatYaml = "yaml"
-	outputFormatJSON = "json"
-)
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "kced",

--- a/deckformat/dbless_test.go
+++ b/deckformat/dbless_test.go
@@ -60,7 +60,7 @@ var _ = Describe("deckformat", func() {
 			deckdata, err := ConvertDBless(MustDeserialize(&jsonData))
 			Expect(err).To(BeNil())
 
-			jsonDeck := MustSerialize(deckdata, false)
+			jsonDeck := MustSerialize(deckdata, OutputFormatJSON)
 			Expect(*jsonDeck).Should(MatchJSON(`{
 				"consumer_groups": [
 					{
@@ -151,7 +151,7 @@ var _ = Describe("deckformat", func() {
 			deckdata, err := ConvertDBless(MustDeserialize(&jsonData))
 			Expect(err).To(BeNil())
 
-			jsonDeck := MustSerialize(deckdata, false)
+			jsonDeck := MustSerialize(deckdata, OutputFormatJSON)
 			Expect(*jsonDeck).Should(MatchJSON(`{
 				"consumer_groups": [
 					{

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -30,10 +30,10 @@ var _ = Describe("Merge", func() {
 			} else {
 				// 'expected' is filename of expected json output, so an error wasn't expected
 				expectedResult := MustReadFile("./merge_testfiles/" + expected)
-				result := MustSerialize(res, false)
+				result := MustSerialize(res, OutputFormatJSON)
 
 				MustWriteSerializedFile("./merge_testfiles/"+
-					strings.Replace(expected, "_expected.", "_generated.", -1), res, false)
+					strings.Replace(expected, "_expected.", "_generated.", -1), res, OutputFormatJSON)
 
 				Expect(*result).To(MatchJSON(*expectedResult))
 			}
@@ -130,7 +130,7 @@ var _ = Describe("Merge", func() {
 			expectedFile := "./merge_testfiles/test1_expected.json"
 
 			res, _ := merge.MustFiles(fileList)
-			result := MustSerialize(res, false)
+			result := MustSerialize(res, OutputFormatJSON)
 			expected := MustReadFile(expectedFile)
 
 			Expect(*result).To(MatchJSON(*expected))

--- a/patch/patch_test.go
+++ b/patch/patch_test.go
@@ -231,7 +231,7 @@ var _ = Describe("Patch", func() {
 			Expect(err).To(BeNil())
 
 			updated := jsonbasics.ConvertToJSONobject(yamlNode)
-			result := MustSerialize(updated, false)
+			result := MustSerialize(updated, OutputFormatJSON)
 			return *result
 		}
 


### PR DESCRIPTION
reduces duplicate code and has the same constant values as deck. also makes the CLI argument case insensitive