### PR TITLE
fix(oas): use google's UUID generator for UUID generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
+	github.com/google/uuid v1.3.1
 	github.com/mozillazg/go-slugify v0.2.0
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
-	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	github.com/vmware-labs/yaml-jsonpath v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -60,8 +62,6 @@ github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+q
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=

--- a/openapi2kong/service.go
+++ b/openapi2kong/service.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 const (
@@ -134,7 +134,7 @@ func createKongUpstream(
 	}
 
 	upstreamName := baseName + ".upstream"
-	upstream["id"] = uuid.NewV5(uuidNamespace, upstreamName).String()
+	upstream["id"] = uuid.NewSHA1(uuidNamespace, []byte(upstreamName)).String()
 	upstream["name"] = upstreamName
 	upstream["tags"] = tags
 
@@ -195,7 +195,7 @@ func CreateKongService(
 	}
 
 	// add id, name and tags to the service
-	service["id"] = uuid.NewV5(uuidNamespace, baseName+".service").String()
+	service["id"] = uuid.NewSHA1(uuidNamespace, []byte(baseName+".service")).String()
 	service["name"] = baseName
 	service["tags"] = tags
 	service["plugins"] = make([]interface{}, 0)

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/google/uuid"
 	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-apiops/logbasics"
-	uuid "github.com/satori/go.uuid"
 )
 
 const JSONSchemaVersion = "draft4"


### PR DESCRIPTION
Hello,

This pull request aims to solve the issue raised here: https://github.com/Kong/go-apiops/issues/82

It replaces the current UUID generation library because of a known CVE. Luckily nothing functionally changes when replacing this with the Google's UUID library. The UUID versions remain the same, meaning version 4 remains version 4 and version 5 remains version 5. Tough, the actual function name is different in Google's library:
 * `NewV4` --> `NewRandom`
 * `NewV5` --> `NewSHA1`

The current testcases seem to cover the changes, except when generating random UUIDs (`docBaseName` in `openapi2kong.go` on line 480), which also happens to not be covered by tests at this moment. If this is required, let me know. Though I'd also wonder how to test this if the UUIDs are randomly generated.

Feedback is welcome.