### PR TITLE
fix(tags): the entitylist for tags was missing acl-groups

### DIFF
--- a/deckformat/entitypointers.go
+++ b/deckformat/entitypointers.go
@@ -11,6 +11,7 @@ var EntityPointers = map[string][]string{
 	// list created from the deck source code, looking at: deck/types/*.go
 	"acls": {
 		"$.acls[*]",
+		"$.consumers[*].acls[*]", // decK specific format for handling many-2-many relationships (consumers <-> groups	)
 	},
 	"basicauth_credentials": {
 		"$.basicauth_credentials[*]",


### PR DESCRIPTION
The format used here is deck specific. It is a table that handles many-to-many relationships; consumers <-> groups. Hence the group name is wrapped in an object to be able to assign tags.