### PR TITLE
fix(oas): align generated names with inso naming

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
-	github.com/mozillazg/go-slugify v0.2.0
+	github.com/kong/go-slugify v0.0.0-20230929094618-0386fb4d426f
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/yaml v0.1.0 h1:YW3WGUoJEXYfzWBjn00zIlrw7brGVD0fUKRYDPAPhrc=
 github.com/invopop/yaml v0.1.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
+github.com/kong/go-slugify v0.0.0-20230929094618-0386fb4d426f h1:ckkce39E0whuMO9DHH8t95JSRiqzLvjBJuLNWVzt8UI=
+github.com/kong/go-slugify v0.0.0-20230929094618-0386fb4d426f/go.mod h1:dbR2h3J2QKXQ1k0aww6cN7o4cIcwlWflr6RKRdcoaiw=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -47,8 +49,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/mozillazg/go-slugify v0.2.0 h1:SIhqDlnJWZH8OdiTmQgeXR28AOnypmAXPeOTcG7b9lk=
-github.com/mozillazg/go-slugify v0.2.0/go.mod h1:z7dPH74PZf2ZPFkyxx+zjPD8CNzRJNa1CGacv0gg8Ns=
 github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4ArmamSUc=
 github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VIwmDmpQ2quyt1aA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/openapi2kong/oas3_testfiles/01-names-inferred.expected.json
+++ b/openapi2kong/oas3_testfiles/01-names-inferred.expected.json
@@ -2,20 +2,20 @@
   "_format_version": "3.0",
   "services": [
     {
-      "host": "simple-api-overview.upstream",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "host": "Simple_API_overview.upstream",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/some/path",
       "plugins": [],
       "port": 80,
       "protocol": "http",
       "routes": [
         {
-          "id": "6fb3ba5b-774a-5b28-aa3c-ab9c6a26b484",
+          "id": "e8e63255-7b5f-52aa-9c17-305b78ad47d8",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_opsid1",
+          "name": "Simple_API_overview-opsid1",
           "paths": [
             "~/$"
           ],
@@ -28,11 +28,11 @@
           ]
         },
         {
-          "id": "2ab3e49d-7565-5ac2-aaee-18d060e2e712",
+          "id": "7b278888-6444-5b79-886d-d229459bd68e",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_~_post",
+          "name": "Simple_API_overview-post",
           "paths": [
             "~/$"
           ],
@@ -45,11 +45,11 @@
           ]
         },
         {
-          "id": "fc7203a1-3b29-5eac-ac56-a1d361e14d97",
+          "id": "63e8e8e9-19ce-58fe-90b6-b6f0403deb51",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_opsid2",
+          "name": "Simple_API_overview-opsid2",
           "paths": [
             "~/application$"
           ],
@@ -62,13 +62,47 @@
           ]
         },
         {
-          "id": "f388efcc-933e-54d5-a549-2b27ef4b935f",
+          "id": "3027eccd-19a1-5b22-a383-75f88e97321c",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_application_post",
+          "name": "Simple_API_overview-application-post",
           "paths": [
             "~/application$"
+          ],
+          "plugins": [],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_01-names-inferred.yaml"
+          ]
+        },
+        {
+          "id": "07e067e8-bb7f-52c3-98e7-28e0b2ac1302",
+          "methods": [
+            "GET"
+          ],
+          "name": "Simple_API_overview-opsid3",
+          "paths": [
+            "~/application/$"
+          ],
+          "plugins": [],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_01-names-inferred.yaml"
+          ]
+        },
+        {
+          "id": "47527799-6eee-56a4-9f70-fd4e0b1a5867",
+          "methods": [
+            "POST"
+          ],
+          "name": "Simple_API_overview-application~-post",
+          "paths": [
+            "~/application/$"
           ],
           "plugins": [],
           "regex_priority": 200,
@@ -87,8 +121,8 @@
   ],
   "upstreams": [
     {
-      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
-      "name": "simple-api-overview.upstream",
+      "id": "dca5eafe-311a-520f-87bc-0e695b01eab6",
+      "name": "Simple_API_overview.upstream",
       "tags": [
         "OAS3_import",
         "OAS3file_01-names-inferred.yaml"

--- a/openapi2kong/oas3_testfiles/01-names-inferred.yaml
+++ b/openapi2kong/oas3_testfiles/01-names-inferred.yaml
@@ -14,25 +14,38 @@ paths:
     get:
       # operation with an ID
       operationId: opsid1
-      responses: 
+      responses:
         '200':
           description: 200 ok
     post:
       # operation without an ID
-      responses: 
+      responses:
         '200':
           description: 200 ok
   /application:
-    # non-empty path
+    # non-empty path, without trailing /
     get:
       # operation with an ID
       operationId: opsid2
-      responses: 
+      responses:
         '200':
           description: 200 ok
     post:
       # operation without an ID
-      responses: 
+      responses:
+        '200':
+          description: 200 ok
+  /application/:
+    # non-empty path, same as above, but with trailing /
+    get:
+      # operation with an ID
+      operationId: opsid3
+      responses:
+        '200':
+          description: 200 ok
+    post:
+      # operation without an ID
+      responses:
         '200':
           description: 200 ok
 

--- a/openapi2kong/oas3_testfiles/02-names-set.expected.json
+++ b/openapi2kong/oas3_testfiles/02-names-set.expected.json
@@ -11,11 +11,11 @@
       "protocol": "http",
       "routes": [
         {
-          "id": "48ab920f-d500-53e2-a5e6-d368b9a4b99c",
+          "id": "8a772dcd-7622-5904-8bda-c4753598afbf",
           "methods": [
             "GET"
           ],
-          "name": "oas-spec-name_opsid1",
+          "name": "oas-spec-name-opsid1",
           "paths": [
             "~/app1$"
           ],
@@ -28,11 +28,11 @@
           ]
         },
         {
-          "id": "85bf9417-31c3-57d4-89e5-5daf7e45869e",
+          "id": "5b3c73d7-0816-53a0-a9ab-3914f16fca06",
           "methods": [
             "POST"
           ],
-          "name": "oas-spec-name_path-name_post",
+          "name": "oas-spec-name-path-name-post",
           "paths": [
             "~/app1$"
           ],
@@ -45,11 +45,11 @@
           ]
         },
         {
-          "id": "c70d6bba-42cb-552d-8c9a-5e6587b80099",
+          "id": "6c573ebb-44d2-5e36-be1a-6aa5e6fc8868",
           "methods": [
             "PUT"
           ],
-          "name": "oas-spec-name_path-name_my-put-operation",
+          "name": "oas-spec-name-path-name-my-put-operation",
           "paths": [
             "~/app1$"
           ],
@@ -62,11 +62,11 @@
           ]
         },
         {
-          "id": "56d986d8-4385-5e7c-82b4-895c6c6ea21b",
+          "id": "38ac897f-100e-5e62-b93c-f4ea6bede9d1",
           "methods": [
             "GET"
           ],
-          "name": "oas-spec-name_opsid2",
+          "name": "oas-spec-name-opsid2",
           "paths": [
             "~/app2$"
           ],
@@ -79,11 +79,11 @@
           ]
         },
         {
-          "id": "0f165a29-0674-58e8-be6c-19968f287dc0",
+          "id": "92d898bf-4bee-5dfe-8dae-4602533ca241",
           "methods": [
             "POST"
           ],
-          "name": "oas-spec-name_app2_post",
+          "name": "oas-spec-name-app2-post",
           "paths": [
             "~/app2$"
           ],
@@ -96,11 +96,11 @@
           ]
         },
         {
-          "id": "88084ff7-bde0-5954-bbcc-d8e563543a5d",
+          "id": "b9b808a1-29e6-596e-8980-f5218aee5440",
           "methods": [
             "PUT"
           ],
-          "name": "oas-spec-name_app2_my-put-operation",
+          "name": "oas-spec-name-app2-my-put-operation",
           "paths": [
             "~/app2$"
           ],

--- a/openapi2kong/oas3_testfiles/03-servers-defaults.expected.json
+++ b/openapi2kong/oas3_testfiles/03-servers-defaults.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "localhost",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "eee036de-517e-59cf-a2e0-17b3adfa31b5",
+          "id": "5879685e-cf66-58a7-b7c5-4e8ef4699dbe",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_opsid",
+          "name": "Simple_API_overview-OpsId",
           "paths": [
             "~/$"
           ],

--- a/openapi2kong/oas3_testfiles/03a-server-no-trailing-slash.expected.json
+++ b/openapi2kong/oas3_testfiles/03a-server-no-trailing-slash.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "example.com",
-      "id": "5434f850-a000-5ad5-8772-1a3cd10811e6",
-      "name": "server-with-no-trailing-slash",
+      "id": "455bef07-544f-551a-b9c8-ac47ed3f35ca",
+      "name": "Server_with_no_trailing_slash",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "d44c95fe-dc1c-596c-8b4a-e18ff50607c4",
+          "id": "2f02798c-98f3-5d02-a9e4-3ff7285148ad",
           "methods": [
             "GET"
           ],
-          "name": "server-with-no-trailing-slash_myid",
+          "name": "Server_with_no_trailing_slash-myId",
           "paths": [
             "~/path$"
           ],

--- a/openapi2kong/oas3_testfiles/04-servers-upstream.expected.json
+++ b/openapi2kong/oas3_testfiles/04-servers-upstream.expected.json
@@ -2,20 +2,20 @@
   "_format_version": "3.0",
   "services": [
     {
-      "host": "simple-api-overview.upstream",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "host": "Simple_API_overview.upstream",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "eee036de-517e-59cf-a2e0-17b3adfa31b5",
+          "id": "5879685e-cf66-58a7-b7c5-4e8ef4699dbe",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_opsid",
+          "name": "Simple_API_overview-OpsId",
           "paths": [
             "~/$"
           ],
@@ -36,8 +36,8 @@
   ],
   "upstreams": [
     {
-      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
-      "name": "simple-api-overview.upstream",
+      "id": "dca5eafe-311a-520f-87bc-0e695b01eab6",
+      "name": "Simple_API_overview.upstream",
       "tags": [
         "OAS3_import",
         "OAS3file_04-servers-upstream.yaml"

--- a/openapi2kong/oas3_testfiles/05-service-defaults-document.expected.json
+++ b/openapi2kong/oas3_testfiles/05-service-defaults-document.expected.json
@@ -3,8 +3,8 @@
   "services": [
     {
       "host": "server1.com",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
@@ -12,11 +12,11 @@
       "retries": 100,
       "routes": [
         {
-          "id": "663104d8-7e60-525d-b506-e42971b4466b",
+          "id": "5f917263-5851-5850-923f-06a35814bb61",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-service",
+          "name": "Simple_API_overview-uses-doc-service",
           "paths": [
             "~/path1$"
           ],
@@ -36,8 +36,8 @@
     },
     {
       "host": "server2.com",
-      "id": "a79c5a8c-0924-599e-9412-39f5a4ff0c3e",
-      "name": "simple-api-overview_path2",
+      "id": "736fd3ce-6b9e-5fd3-99f8-4ba04e2c5bfb",
+      "name": "Simple_API_overview-path2",
       "path": "/",
       "plugins": [],
       "port": 443,
@@ -45,11 +45,11 @@
       "retries": 100,
       "routes": [
         {
-          "id": "c1b84366-8ff8-57b9-b118-bedd1b9ab1c8",
+          "id": "348c51b0-4d2d-5f9f-ba1a-59d35f9bc690",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-path-service",
+          "name": "Simple_API_overview-uses-path-service",
           "paths": [
             "~/path2$"
           ],
@@ -69,8 +69,8 @@
     },
     {
       "host": "server3.com",
-      "id": "5d05e040-c551-50a1-90e7-6af5d3a7c0dc",
-      "name": "simple-api-overview_uses-ops-service",
+      "id": "735eee51-e5e6-5280-8aaa-544f407f14b6",
+      "name": "Simple_API_overview-uses-ops-service",
       "path": "/",
       "plugins": [],
       "port": 443,
@@ -78,11 +78,11 @@
       "retries": 100,
       "routes": [
         {
-          "id": "ca1c6faa-7076-5a09-9346-9c9dc3e019cb",
+          "id": "3a12e644-b346-5d53-873f-673fd16cf522",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-ops-service",
+          "name": "Simple_API_overview-uses-ops-service",
           "paths": [
             "~/path2$"
           ],

--- a/openapi2kong/oas3_testfiles/06-upstream-defaults-document.expected.json
+++ b/openapi2kong/oas3_testfiles/06-upstream-defaults-document.expected.json
@@ -2,20 +2,20 @@
   "_format_version": "3.0",
   "services": [
     {
-      "host": "simple-api-overview.upstream",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "host": "Simple_API_overview.upstream",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "663104d8-7e60-525d-b506-e42971b4466b",
+          "id": "5f917263-5851-5850-923f-06a35814bb61",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-service",
+          "name": "Simple_API_overview-uses-doc-service",
           "paths": [
             "~/path1$"
           ],
@@ -34,20 +34,20 @@
       ]
     },
     {
-      "host": "simple-api-overview_path2.upstream",
-      "id": "a79c5a8c-0924-599e-9412-39f5a4ff0c3e",
-      "name": "simple-api-overview_path2",
+      "host": "Simple_API_overview-path2.upstream",
+      "id": "736fd3ce-6b9e-5fd3-99f8-4ba04e2c5bfb",
+      "name": "Simple_API_overview-path2",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "c1b84366-8ff8-57b9-b118-bedd1b9ab1c8",
+          "id": "348c51b0-4d2d-5f9f-ba1a-59d35f9bc690",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-path-service",
+          "name": "Simple_API_overview-uses-path-service",
           "paths": [
             "~/path2$"
           ],
@@ -66,20 +66,20 @@
       ]
     },
     {
-      "host": "simple-api-overview_uses-ops-service.upstream",
-      "id": "5d05e040-c551-50a1-90e7-6af5d3a7c0dc",
-      "name": "simple-api-overview_uses-ops-service",
+      "host": "Simple_API_overview-uses-ops-service.upstream",
+      "id": "735eee51-e5e6-5280-8aaa-544f407f14b6",
+      "name": "Simple_API_overview-uses-ops-service",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "ca1c6faa-7076-5a09-9346-9c9dc3e019cb",
+          "id": "3a12e644-b346-5d53-873f-673fd16cf522",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-ops-service",
+          "name": "Simple_API_overview-uses-ops-service",
           "paths": [
             "~/path2$"
           ],
@@ -100,8 +100,8 @@
   ],
   "upstreams": [
     {
-      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
-      "name": "simple-api-overview.upstream",
+      "id": "dca5eafe-311a-520f-87bc-0e695b01eab6",
+      "name": "Simple_API_overview.upstream",
       "slots": 1000,
       "tags": [
         "OAS3_import",
@@ -118,8 +118,8 @@
       ]
     },
     {
-      "id": "ef3215c6-42e1-5380-ad2d-24f3b2d05972",
-      "name": "simple-api-overview_path2.upstream",
+      "id": "bd23de0b-b8cd-5b71-9fa3-b3b4f32938b2",
+      "name": "Simple_API_overview-path2.upstream",
       "slots": 2000,
       "tags": [
         "OAS3_import",
@@ -136,8 +136,8 @@
       ]
     },
     {
-      "id": "e2aac4d8-a96f-50ec-b71e-980e6e581a50",
-      "name": "simple-api-overview_uses-ops-service.upstream",
+      "id": "d7507c89-41bd-5eca-8f7b-874d06af6670",
+      "name": "Simple_API_overview-uses-ops-service.upstream",
       "slots": 3000,
       "tags": [
         "OAS3_import",

--- a/openapi2kong/oas3_testfiles/06a-upstream-defaults.expected.json
+++ b/openapi2kong/oas3_testfiles/06a-upstream-defaults.expected.json
@@ -2,20 +2,20 @@
   "_format_version": "3.0",
   "services": [
     {
-      "host": "simple-api-overview.upstream",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "host": "Simple_API_overview.upstream",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/anything",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "663104d8-7e60-525d-b506-e42971b4466b",
+          "id": "5f917263-5851-5850-923f-06a35814bb61",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-service",
+          "name": "Simple_API_overview-uses-doc-service",
           "paths": [
             "~/path1$"
           ],
@@ -36,8 +36,8 @@
   ],
   "upstreams": [
     {
-      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
-      "name": "simple-api-overview.upstream",
+      "id": "dca5eafe-311a-520f-87bc-0e695b01eab6",
+      "name": "Simple_API_overview.upstream",
       "tags": [
         "OAS3_import",
         "OAS3file_06a-upstream-defaults.yaml"

--- a/openapi2kong/oas3_testfiles/07-service-defaults-overrides.expected.json
+++ b/openapi2kong/oas3_testfiles/07-service-defaults-overrides.expected.json
@@ -2,9 +2,9 @@
   "_format_version": "3.0",
   "services": [
     {
-      "host": "simple-api-overview.upstream",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "host": "Simple_API_overview.upstream",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
@@ -12,11 +12,11 @@
       "retries": 100,
       "routes": [
         {
-          "id": "663104d8-7e60-525d-b506-e42971b4466b",
+          "id": "5f917263-5851-5850-923f-06a35814bb61",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-service",
+          "name": "Simple_API_overview-uses-doc-service",
           "paths": [
             "~/path1$"
           ],
@@ -35,9 +35,9 @@
       ]
     },
     {
-      "host": "simple-api-overview.upstream",
-      "id": "a79c5a8c-0924-599e-9412-39f5a4ff0c3e",
-      "name": "simple-api-overview_path2",
+      "host": "Simple_API_overview.upstream",
+      "id": "736fd3ce-6b9e-5fd3-99f8-4ba04e2c5bfb",
+      "name": "Simple_API_overview-path2",
       "path": "/",
       "plugins": [],
       "port": 443,
@@ -45,11 +45,11 @@
       "retries": 200,
       "routes": [
         {
-          "id": "c1b84366-8ff8-57b9-b118-bedd1b9ab1c8",
+          "id": "348c51b0-4d2d-5f9f-ba1a-59d35f9bc690",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-path-service",
+          "name": "Simple_API_overview-uses-path-service",
           "paths": [
             "~/path2$"
           ],
@@ -68,9 +68,9 @@
       ]
     },
     {
-      "host": "simple-api-overview.upstream",
-      "id": "5d05e040-c551-50a1-90e7-6af5d3a7c0dc",
-      "name": "simple-api-overview_uses-ops-service",
+      "host": "Simple_API_overview.upstream",
+      "id": "735eee51-e5e6-5280-8aaa-544f407f14b6",
+      "name": "Simple_API_overview-uses-ops-service",
       "path": "/",
       "plugins": [],
       "port": 443,
@@ -78,11 +78,11 @@
       "retries": 300,
       "routes": [
         {
-          "id": "ca1c6faa-7076-5a09-9346-9c9dc3e019cb",
+          "id": "3a12e644-b346-5d53-873f-673fd16cf522",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-ops-service",
+          "name": "Simple_API_overview-uses-ops-service",
           "paths": [
             "~/path2$"
           ],
@@ -103,8 +103,8 @@
   ],
   "upstreams": [
     {
-      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
-      "name": "simple-api-overview.upstream",
+      "id": "dca5eafe-311a-520f-87bc-0e695b01eab6",
+      "name": "Simple_API_overview.upstream",
       "tags": [
         "OAS3_import",
         "OAS3file_07-service-defaults-overrides.yaml"

--- a/openapi2kong/oas3_testfiles/07a-service-defaults.expected.json
+++ b/openapi2kong/oas3_testfiles/07a-service-defaults.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "myhost.com",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/something",
       "plugins": [],
       "port": 123,
       "protocol": "http",
       "routes": [
         {
-          "id": "663104d8-7e60-525d-b506-e42971b4466b",
+          "id": "5f917263-5851-5850-923f-06a35814bb61",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-service",
+          "name": "Simple_API_overview-uses-doc-service",
           "paths": [
             "~/path1$"
           ],

--- a/openapi2kong/oas3_testfiles/08-route-defaults-overrides.expected.json
+++ b/openapi2kong/oas3_testfiles/08-route-defaults-overrides.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "server1.com",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "44777959-fdbe-5873-a5c1-beabbc822656",
+          "id": "d0aae8cc-da4b-53db-9236-484de50e7624",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-defaults",
+          "name": "Simple_API_overview-uses-doc-defaults",
           "paths": [
             "~/path1$"
           ],
@@ -28,11 +28,11 @@
           ]
         },
         {
-          "id": "a8cf87ef-dae0-5948-93e4-48f579fe12a0",
+          "id": "4762d9cd-18b9-5ab6-9751-f729317f3099",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-path-defaults",
+          "name": "Simple_API_overview-uses-path-defaults",
           "paths": [
             "~/path2$"
           ],
@@ -45,11 +45,11 @@
           ]
         },
         {
-          "id": "5a98eef7-b0d2-572e-8656-4654a89c4179",
+          "id": "90e714b1-7668-51c4-9a3e-ade66ba2b57f",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-ops-defaults",
+          "name": "Simple_API_overview-uses-ops-defaults",
           "paths": [
             "~/path2$"
           ],

--- a/openapi2kong/oas3_testfiles/09-generic-plugins.expected.json
+++ b/openapi2kong/oas3_testfiles/09-generic-plugins.expected.json
@@ -3,8 +3,8 @@
   "services": [
     {
       "host": "server1.com",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [
         {
@@ -12,7 +12,7 @@
             "message": "So long and thanks for all the fish!",
             "status_code": 403
           },
-          "id": "ef93d30f-dc7d-581b-8b1b-3f8942a0d171",
+          "id": "3a0a598e-5e31-570d-abcc-563876fa0a0b",
           "name": "request-termination",
           "tags": [
             "OAS3_import",
@@ -24,11 +24,11 @@
       "protocol": "https",
       "routes": [
         {
-          "id": "d020c736-e762-5dad-8415-1684ee4f2061",
+          "id": "8062e64f-dce4-5ae1-aa55-b2c3a1ae9422",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-plugin",
+          "name": "Simple_API_overview-uses-doc-plugin",
           "paths": [
             "~/path1$"
           ],
@@ -41,11 +41,11 @@
           ]
         },
         {
-          "id": "ef2ca083-29b3-5d7b-87c5-e4315d830c33",
+          "id": "f875b5f9-2e16-52ef-9f83-a407a1b73a32",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-path-plugin",
+          "name": "Simple_API_overview-uses-path-plugin",
           "paths": [
             "~/path2$"
           ],
@@ -55,7 +55,7 @@
                 "message": "The answer to life, the universe, and everything!",
                 "status_code": 403
               },
-              "id": "aa56031e-7155-599f-a9e9-93e6b271ba58",
+              "id": "c518bbe3-0e8b-53bc-b845-733fc4e98fe8",
               "name": "request-termination",
               "tags": [
                 "OAS3_import",
@@ -71,11 +71,11 @@
           ]
         },
         {
-          "id": "f9c8a7d7-3518-5c25-b66b-40943e59f91b",
+          "id": "32e8ee5a-df88-5e35-888d-ef404543a91d",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-ops-plugin",
+          "name": "Simple_API_overview-uses-ops-plugin",
           "paths": [
             "~/path2$"
           ],
@@ -85,7 +85,7 @@
                 "message": "For a moment, nothing happened. Then, after a second or so, nothing continued to happen.",
                 "status_code": 403
               },
-              "id": "ead16074-ccb0-52dd-9f56-4193529e8ffa",
+              "id": "c2294326-c1e8-55ae-8f2f-e1a612556beb",
               "name": "request-termination",
               "tags": [
                 "OAS3_import",

--- a/openapi2kong/oas3_testfiles/09a-plugins-with-consumers.expected.json
+++ b/openapi2kong/oas3_testfiles/09a-plugins-with-consumers.expected.json
@@ -3,13 +3,13 @@
   "plugins": [
     {
       "config": {
-        "message": "The answer to life, the universe, and everything!",
+        "message": "So long and thanks for all the fish!",
         "status_code": 403
       },
-      "consumer": "johndoe2",
-      "id": "aa56031e-7155-599f-a9e9-93e6b271ba58",
+      "consumer": "johndoe1",
+      "id": "3a0a598e-5e31-570d-abcc-563876fa0a0b",
       "name": "request-termination",
-      "route": "simple-api-overview_uses-path-plugin",
+      "service": "Simple_API_overview",
       "tags": [
         "OAS3_import",
         "OAS3file_09a-plugins-with-consumers.yaml"
@@ -21,9 +21,9 @@
         "status_code": 403
       },
       "consumer": "johndoe3",
-      "id": "ead16074-ccb0-52dd-9f56-4193529e8ffa",
+      "id": "c2294326-c1e8-55ae-8f2f-e1a612556beb",
       "name": "request-termination",
-      "route": "simple-api-overview_uses-ops-plugin",
+      "route": "Simple_API_overview-uses-ops-plugin",
       "tags": [
         "OAS3_import",
         "OAS3file_09a-plugins-with-consumers.yaml"
@@ -31,13 +31,13 @@
     },
     {
       "config": {
-        "message": "So long and thanks for all the fish!",
+        "message": "The answer to life, the universe, and everything!",
         "status_code": 403
       },
-      "consumer": "johndoe1",
-      "id": "ef93d30f-dc7d-581b-8b1b-3f8942a0d171",
+      "consumer": "johndoe2",
+      "id": "c518bbe3-0e8b-53bc-b845-733fc4e98fe8",
       "name": "request-termination",
-      "service": "simple-api-overview",
+      "route": "Simple_API_overview-uses-path-plugin",
       "tags": [
         "OAS3_import",
         "OAS3file_09a-plugins-with-consumers.yaml"
@@ -47,19 +47,19 @@
   "services": [
     {
       "host": "server1.com",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "d020c736-e762-5dad-8415-1684ee4f2061",
+          "id": "8062e64f-dce4-5ae1-aa55-b2c3a1ae9422",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-plugin",
+          "name": "Simple_API_overview-uses-doc-plugin",
           "paths": [
             "~/path1$"
           ],
@@ -72,11 +72,11 @@
           ]
         },
         {
-          "id": "ef2ca083-29b3-5d7b-87c5-e4315d830c33",
+          "id": "f875b5f9-2e16-52ef-9f83-a407a1b73a32",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-path-plugin",
+          "name": "Simple_API_overview-uses-path-plugin",
           "paths": [
             "~/path2$"
           ],
@@ -89,11 +89,11 @@
           ]
         },
         {
-          "id": "f9c8a7d7-3518-5c25-b66b-40943e59f91b",
+          "id": "32e8ee5a-df88-5e35-888d-ef404543a91d",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-ops-plugin",
+          "name": "Simple_API_overview-uses-ops-plugin",
           "paths": [
             "~/path2$"
           ],

--- a/openapi2kong/oas3_testfiles/10-generic-plugins-multi-service.expected.json
+++ b/openapi2kong/oas3_testfiles/10-generic-plugins-multi-service.expected.json
@@ -3,8 +3,8 @@
   "services": [
     {
       "host": "server1.com",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [
         {
@@ -12,7 +12,7 @@
             "message": "So long and thanks for all the fish!",
             "status_code": 403
           },
-          "id": "ef93d30f-dc7d-581b-8b1b-3f8942a0d171",
+          "id": "3a0a598e-5e31-570d-abcc-563876fa0a0b",
           "name": "request-termination",
           "tags": [
             "OAS3_import",
@@ -24,11 +24,11 @@
       "protocol": "https",
       "routes": [
         {
-          "id": "ef8405d9-7cbc-5574-901e-50a8cb63fe6f",
+          "id": "c7218170-3989-54f0-8f39-766c6a361a4a",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-service-and-plugins",
+          "name": "Simple_API_overview-uses-doc-service-and-plugins",
           "paths": [
             "~/path1$"
           ],
@@ -48,8 +48,8 @@
     },
     {
       "host": "server1.com",
-      "id": "a79c5a8c-0924-599e-9412-39f5a4ff0c3e",
-      "name": "simple-api-overview_path2",
+      "id": "736fd3ce-6b9e-5fd3-99f8-4ba04e2c5bfb",
+      "name": "Simple_API_overview-path2",
       "path": "/",
       "plugins": [
         {
@@ -57,7 +57,7 @@
             "message": "So long and thanks for all the fish!",
             "status_code": 403
           },
-          "id": "e1095950-df7f-5747-afd1-36355f4510ae",
+          "id": "e5e5bad1-4b75-50ea-a9d4-0c5f5b286186",
           "name": "request-termination",
           "tags": [
             "OAS3_import",
@@ -65,7 +65,7 @@
           ]
         },
         {
-          "id": "44b80499-0367-5fb6-b1b3-3d0e3281acad",
+          "id": "f35b17d9-4776-55a6-8921-37356801febe",
           "name": "some-plugin1",
           "tags": [
             "OAS3_import",
@@ -77,17 +77,17 @@
       "protocol": "https",
       "routes": [
         {
-          "id": "a065359f-f1b2-5bc3-b32a-4b97992cbd9b",
+          "id": "30e6d240-df1b-52fb-9454-4c9bb8e925fa",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_uses-doc-plugin-on-path-service",
+          "name": "Simple_API_overview-uses-doc-plugin-on-path-service",
           "paths": [
             "~/path2$"
           ],
           "plugins": [
             {
-              "id": "a9ddfff9-6672-5471-84a7-bfccae5d74b2",
+              "id": "b6e9d153-d9fa-5ed4-8ccf-dc2f804116b8",
               "name": "some-plugin2",
               "tags": [
                 "OAS3_import",
@@ -110,19 +110,19 @@
     },
     {
       "host": "server1.com",
-      "id": "95802912-cfa1-5edf-876b-0fd23729e46e",
-      "name": "simple-api-overview_uses-plugins-on-ops-level",
+      "id": "ae8bf3e0-20e4-5334-8d1d-269be9ae317e",
+      "name": "Simple_API_overview-uses-plugins-on-ops-level",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "042a9169-97e8-5177-9f53-0d5067f4f139",
+          "id": "559b1a1f-a52f-5135-969a-36f0618e29d6",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview_uses-plugins-on-ops-level",
+          "name": "Simple_API_overview-uses-plugins-on-ops-level",
           "paths": [
             "~/path2$"
           ],
@@ -132,7 +132,7 @@
                 "message": "So long and thanks for all the fish!",
                 "status_code": 403
               },
-              "id": "4a6df652-011a-5f76-b1b4-460ab5c86da9",
+              "id": "d366808f-40f7-5959-9069-3b4fa8b2f6f8",
               "name": "request-termination",
               "tags": [
                 "OAS3_import",
@@ -140,7 +140,7 @@
               ]
             },
             {
-              "id": "2736254d-7317-5d57-a9e9-9b3cf1c6489e",
+              "id": "a6efc119-b231-586f-abdc-1add12976029",
               "name": "some-plugin1",
               "tags": [
                 "OAS3_import",
@@ -148,7 +148,7 @@
               ]
             },
             {
-              "id": "c8d30b7f-fc60-5791-b31a-7bf6eb83b0b3",
+              "id": "cf13025d-7a2d-5738-9347-d1b5f6de7746",
               "name": "some-plugin3",
               "tags": [
                 "OAS3_import",

--- a/openapi2kong/oas3_testfiles/11-references.expected.json
+++ b/openapi2kong/oas3_testfiles/11-references.expected.json
@@ -2,16 +2,16 @@
   "_format_version": "3.0",
   "services": [
     {
-      "host": "simple-api-overview.upstream",
-      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
-      "name": "simple-api-overview",
+      "host": "Simple_API_overview.upstream",
+      "id": "e3a95664-95d7-5b10-bc3d-11c9cc6c2b4e",
+      "name": "Simple_API_overview",
       "path": "/",
       "plugins": [
         {
           "config": {
             "path": "/dev/stderr"
           },
-          "id": "b4eb8681-bd93-5d4b-9c19-702a9452e972",
+          "id": "cb1b758a-0dba-596d-83ce-802d320b5b86",
           "name": "file-log",
           "tags": [
             "OAS3_import",
@@ -24,11 +24,11 @@
       "retries": 999,
       "routes": [
         {
-          "id": "ef141006-f57c-5a01-ae4a-2a83a671ff76",
+          "id": "951ce441-de7d-57ca-ab9f-e2e5cd315360",
           "methods": [
             "GET"
           ],
-          "name": "simple-api-overview_path1_get",
+          "name": "Simple_API_overview-path1-get",
           "paths": [
             "~/path1$"
           ],
@@ -49,8 +49,8 @@
   ],
   "upstreams": [
     {
-      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
-      "name": "simple-api-overview.upstream",
+      "id": "dca5eafe-311a-520f-87bc-0e695b01eab6",
+      "name": "Simple_API_overview.upstream",
       "slots": 999,
       "tags": [
         "OAS3_import",

--- a/openapi2kong/oas3_testfiles/12-path-parameter-regex.expected.json
+++ b/openapi2kong/oas3_testfiles/12-path-parameter-regex.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "example.com",
-      "id": "520e4991-2d1a-59b8-bf2e-579cca0969a0",
-      "name": "path-parameter-test",
+      "id": "3e0fefa1-06b5-589a-ab2d-2d01c70bf55a",
+      "name": "Path_parameter_test",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "38dcec89-d67c-5f67-ab5e-b38cc2180f77",
+          "id": "d24ac8a3-d744-5952-89a9-79cffecbf8dd",
           "methods": [
             "GET"
           ],
-          "name": "path-parameter-test_getbatchnoparams",
+          "name": "Path_parameter_test-getBatchNoParams",
           "paths": [
             "~/batchs\\(Material='iron',Batch='10'\\)$"
           ],
@@ -28,13 +28,13 @@
           ]
         },
         {
-          "id": "2af1536a-706a-5941-b3fe-2682e031edf9",
+          "id": "928231e6-951a-50ff-8891-bc9f9d12538b",
           "methods": [
             "GET"
           ],
-          "name": "path-parameter-test_getbatchwithparams",
+          "name": "Path_parameter_test-getBatchWithParams",
           "paths": [
-            "~/batchs\\(Material='(?<material>[^#?/]+)',Batch='(?<batch>[^#?/]+)'\\)$"
+            "~/batchs\\(Material='(?\u003cMaterial\u003e[^#?/]+)',Batch='(?\u003cBatch\u003e[^#?/]+)'\\)$"
           ],
           "plugins": [],
           "regex_priority": 100,
@@ -45,13 +45,13 @@
           ]
         },
         {
-          "id": "8438e81a-7724-53a2-9b5b-5bb400ac8531",
+          "id": "95358c02-e755-5a0c-9044-bf9a9b4e1561",
           "methods": [
             "POST"
           ],
-          "name": "path-parameter-test_postbatchwithparams",
+          "name": "Path_parameter_test-postBatchWithParams",
           "paths": [
-            "~/batchs\\(Material='(?<material>[^#?/]+)',Batch='(?<batch>[^#?/]+)'\\)$"
+            "~/batchs\\(Material='(?\u003cMaterial\u003e[^#?/]+)',Batch='(?\u003cBatch\u003e[^#?/]+)'\\)$"
           ],
           "plugins": [],
           "regex_priority": 100,
@@ -62,13 +62,13 @@
           ]
         },
         {
-          "id": "0da1f8dc-e918-5379-b3b0-ffc061ae1691",
+          "id": "2f9299ba-2694-52a8-8e82-bd2d3446bc41",
           "methods": [
             "GET"
           ],
-          "name": "path-parameter-test_opsid",
+          "name": "Path_parameter_test-opsid",
           "paths": [
-            "~/demo/(?<something>[^#?/]+)/else/(?<to_do>[^#?/]+)/$"
+            "~/demo/(?\u003csomething\u003e[^#?/]+)/else/(?\u003ca_to_do\u003e[^#?/]+)/$"
           ],
           "plugins": [],
           "regex_priority": 100,

--- a/openapi2kong/oas3_testfiles/12-path-parameter-regex.expected.json
+++ b/openapi2kong/oas3_testfiles/12-path-parameter-regex.expected.json
@@ -34,7 +34,7 @@
           ],
           "name": "Path_parameter_test-getBatchWithParams",
           "paths": [
-            "~/batchs\\(Material='(?\u003cmaterial\u003e[^#?/]+)',Batch='(?\u003cbatch\u003e[^#?/]+)'\\)$"
+            "~/batchs\\(Material='(?<material>[^#?/]+)',Batch='(?<batch>[^#?/]+)'\\)$"
           ],
           "plugins": [],
           "regex_priority": 100,
@@ -51,7 +51,7 @@
           ],
           "name": "Path_parameter_test-postBatchWithParams",
           "paths": [
-            "~/batchs\\(Material='(?\u003cmaterial\u003e[^#?/]+)',Batch='(?\u003cbatch\u003e[^#?/]+)'\\)$"
+            "~/batchs\\(Material='(?<material>[^#?/]+)',Batch='(?<batch>[^#?/]+)'\\)$"
           ],
           "plugins": [],
           "regex_priority": 100,
@@ -68,7 +68,7 @@
           ],
           "name": "Path_parameter_test-opsid",
           "paths": [
-            "~/demo/(?\u003csomething\u003e[^#?/]+)/else/(?\u003cto_do\u003e[^#?/]+)/$"
+            "~/demo/(?<something>[^#?/]+)/else/(?<to_do>[^#?/]+)/$"
           ],
           "plugins": [],
           "regex_priority": 100,

--- a/openapi2kong/oas3_testfiles/12-path-parameter-regex.expected.json
+++ b/openapi2kong/oas3_testfiles/12-path-parameter-regex.expected.json
@@ -34,7 +34,7 @@
           ],
           "name": "Path_parameter_test-getBatchWithParams",
           "paths": [
-            "~/batchs\\(Material='(?\u003cMaterial\u003e[^#?/]+)',Batch='(?\u003cBatch\u003e[^#?/]+)'\\)$"
+            "~/batchs\\(Material='(?\u003cmaterial\u003e[^#?/]+)',Batch='(?\u003cbatch\u003e[^#?/]+)'\\)$"
           ],
           "plugins": [],
           "regex_priority": 100,
@@ -51,7 +51,7 @@
           ],
           "name": "Path_parameter_test-postBatchWithParams",
           "paths": [
-            "~/batchs\\(Material='(?\u003cMaterial\u003e[^#?/]+)',Batch='(?\u003cBatch\u003e[^#?/]+)'\\)$"
+            "~/batchs\\(Material='(?\u003cmaterial\u003e[^#?/]+)',Batch='(?\u003cbatch\u003e[^#?/]+)'\\)$"
           ],
           "plugins": [],
           "regex_priority": 100,
@@ -68,7 +68,7 @@
           ],
           "name": "Path_parameter_test-opsid",
           "paths": [
-            "~/demo/(?\u003csomething\u003e[^#?/]+)/else/(?\u003ca_to_do\u003e[^#?/]+)/$"
+            "~/demo/(?\u003csomething\u003e[^#?/]+)/else/(?\u003cto_do\u003e[^#?/]+)/$"
           ],
           "plugins": [],
           "regex_priority": 100,

--- a/openapi2kong/oas3_testfiles/13-request-validator-plugin.expected.json
+++ b/openapi2kong/oas3_testfiles/13-request-validator-plugin.expected.json
@@ -84,7 +84,7 @@
           ],
           "name": "Example-params__path-id-get",
           "paths": [
-            "~/params/(?\u003cpath_id\u003e[^#?/]+)$"
+            "~/params/(?<path_id>[^#?/]+)$"
           ],
           "plugins": [
             {

--- a/openapi2kong/oas3_testfiles/13-request-validator-plugin.expected.json
+++ b/openapi2kong/oas3_testfiles/13-request-validator-plugin.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "backend.com",
-      "id": "730d612d-914b-5fe8-8ead-e6aa654318ef",
-      "name": "example",
+      "id": "9f542908-e00d-55bc-a260-3864a9b6b8d2",
+      "name": "Example",
       "path": "/path",
       "plugins": [],
       "port": 80,
       "protocol": "http",
       "routes": [
         {
-          "id": "2a2f7451-7df1-5c42-8f6c-5319ae6e4936",
+          "id": "3b43a41e-036b-58c8-9692-af14ba57ed81",
           "methods": [
             "POST"
           ],
-          "name": "example_body_post",
+          "name": "Example-body-post",
           "paths": [
             "~/body$"
           ],
@@ -29,7 +29,7 @@
                 "body_schema": "{\"$ref\":\"#/definitions/jsonSchema\",\"definitions\":{\"jsonSchema\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\"}}}",
                 "version": "draft4"
               },
-              "id": "ce17156b-dfb5-55f0-86b4-9abeb919bae3",
+              "id": "9ca9813e-4a6e-59e1-ad10-2d33908b8190",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",
@@ -45,11 +45,11 @@
           ]
         },
         {
-          "id": "6d59c2fe-e723-5238-a847-d87d8e8bb7fc",
+          "id": "19b82973-eb82-5a24-b6e9-6f5930dbf9eb",
           "methods": [
             "GET"
           ],
-          "name": "example_global_get",
+          "name": "Example-global-get",
           "paths": [
             "~/global$"
           ],
@@ -62,7 +62,7 @@
                 "body_schema": "{\"$ref\":\"#/definitions/jsonSchema\",\"definitions\":{\"jsonSchema\":{\"properties\":{\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},\"type\":\"object\"}}}",
                 "version": "draft4"
               },
-              "id": "2b68c247-3cab-54a1-a98b-cb6100caf370",
+              "id": "a122ed01-a687-50e1-b6b4-10f0c42b2b85",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",
@@ -78,11 +78,11 @@
           ]
         },
         {
-          "id": "6d4dfd63-5d87-5c9d-84dc-9e146b27e4fb",
+          "id": "26d60104-349e-5fa3-af66-5d08ff5c4fbe",
           "methods": [
             "GET"
           ],
-          "name": "example_params-path-id_get",
+          "name": "Example-params__path-id-get",
           "paths": [
             "~/params/(?\u003cpath_id\u003e[^#?/]+)$"
           ],
@@ -127,7 +127,7 @@
                 "version": "draft4"
               },
               "enabled": true,
-              "id": "98eedac8-4afc-5f2b-aaa2-d73a1297bca5",
+              "id": "c5bbae2e-9948-5a51-93b2-9051187cb543",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",

--- a/openapi2kong/oas3_testfiles/14-no-request-validator-plugin.expected.json
+++ b/openapi2kong/oas3_testfiles/14-no-request-validator-plugin.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "httpbin.org",
-      "id": "069ec36b-308c-5cf4-8536-b7bad57907ea",
-      "name": "mock-target-api",
+      "id": "d2db261f-f226-50b2-b687-1f93e7fd6cc0",
+      "name": "Mock_Target_API",
       "path": "/anything",
       "plugins": [],
       "port": 80,
       "protocol": "http",
       "routes": [
         {
-          "id": "34dc34c8-2b0e-539b-9a6c-8b0ff4cd9fbb",
+          "id": "ac42f5d5-17a5-5a48-85ff-fa72043fb95b",
           "methods": [
             "GET"
           ],
-          "name": "mock-target-api_gethelp",
+          "name": "Mock_Target_API-getHelp",
           "paths": [
             "~/help$"
           ],
@@ -28,11 +28,11 @@
           ]
         },
         {
-          "id": "34dc34c8-2b0e-539b-9a6c-8b0ff4cd9fbb",
+          "id": "ac42f5d5-17a5-5a48-85ff-fa72043fb95b",
           "methods": [
             "GET"
           ],
-          "name": "mock-target-api_gethelp",
+          "name": "Mock_Target_API-getHelp",
           "paths": [
             "~/user$"
           ],
@@ -45,7 +45,7 @@
                 "body_schema": "{}",
                 "version": "draft4"
               },
-              "id": "40037e1a-ea6d-5d78-85b2-7f502e4a60e9",
+              "id": "5f8d13be-1d21-5c16-813c-99db74abf5d6",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",

--- a/openapi2kong/oas3_testfiles/15-circular-requestBody-schema.expected.json
+++ b/openapi2kong/oas3_testfiles/15-circular-requestBody-schema.expected.json
@@ -3,19 +3,19 @@
   "services": [
     {
       "host": "some.random.url",
-      "id": "68804eaf-310b-508e-ae22-fe6a7b9ab716",
-      "name": "testing-circular",
+      "id": "1939ff6a-077c-5499-9f65-5d2f4d8d7e37",
+      "name": "Testing_Circular",
       "path": "/",
       "plugins": [],
       "port": 443,
       "protocol": "https",
       "routes": [
         {
-          "id": "761badfc-6c93-585c-a5ed-cee7559aad27",
+          "id": "b2a6949f-c6fa-5446-97b5-92d9fde0be4e",
           "methods": [
             "POST"
           ],
-          "name": "testing-circular_testing_post",
+          "name": "Testing_Circular-testing-post",
           "paths": [
             "~/testing$"
           ],
@@ -30,7 +30,7 @@
                 "version": "draft4"
               },
               "enabled": true,
-              "id": "72eaa98a-0562-5669-9ee8-45d0fa479e7d",
+              "id": "1b028a78-49dd-51ef-9ffa-1ac75ce99d91",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -53,6 +53,8 @@ func Slugify(name ...string) string {
 // The returned name will be valid for PCRE regex captures; Alphanumeric + '_', starting
 // with [a-zA-Z].
 func sanitizeRegexCapture(varName string) string {
+	slugify.ToLower = true
+	slugify.Separator = "-"
 	varName = slugify.Slugify(varName)
 	varName = strings.ReplaceAll(varName, "-", "_")
 	if strings.HasPrefix(varName, "_") {


### PR DESCRIPTION
Names generated were slightly different from the names generated
by Inso. This lines them up.
This is however not 100% acurate. Inso had an issue with generating
duplicate names if there were 2 identical paths, with and without
trailing slash (/). So here we add "~" as indicator of a trailing
slash. Other differences might be in the way non-english characters
are slugified. Things like; "北京kožušček"