### PR TITLE
feat(patch): add arrays to CLI options

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -46,7 +46,7 @@ func executePatch(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to retrieve '--value' entries; %w", err)
 		}
-		valuesPatch.ObjValues, valuesPatch.Remove, err = patch.ValidateValuesFlags(values)
+		valuesPatch.ObjValues, valuesPatch.Remove, valuesPatch.ArrValues, err = patch.ValidateValuesFlags(values)
 		if err != nil {
 			return fmt.Errorf("failed parsing '--value' entry; %w", err)
 		}


### PR DESCRIPTION
the `--value` flag only supported object fields, for arrays using a patch file was required. This change now supports a `--value "[1,2,3]"` format for arrays.