### PR TITLE
Adds some deck file lint documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -151,6 +151,66 @@ patches:
 ```
 
 ---
+### `lint`
+
+The `lint` command is used as a validation tool to analyze declarative configuration files for errors or undesirable configurations. 
+`lint` is compatible with [Spectral](https://github.com/stoplightio/spectral) rulesets and can operate on either JSON or YAML format files including
+OpenAPI specifications or decK configuration files. 
+
+The command is invoked by providing a ruleset file as an argument which is evaluated against an input file using the `-s` flag.
+
+```sh
+Usage:
+  deck file lint [flags] ruleset-file
+
+Flags:
+  -D, --display-only-failures   only output results equal to or greater than --fail-severity
+  -F, --fail-severity string    results of this level or above will trigger a failure exit code
+                                [choices: "error", "warn", "info", "hint"] (default "error")
+      --format string           output format [choices: "plain", "json", "yaml"] (default "plain")
+  -h, --help                    help for lint
+  -o, --output-file string      Output file to write to. Use - to write to stdout. (default "-")
+  -s, --state string            decK file to process. Use - to read from stdin. (default "-")
+```
+
+For example, to verify that a decK file contains the `3.1` version, create a ruleset file containing the following:
+
+```yaml
+rules:
+  version-check:
+    description: "Validate version 3.1 for decK files"
+    given: $._format_version
+    severity: error
+    then:
+      function: pattern
+      functionOptions:
+        match: "^3.1$"
+```
+
+The following decK file snippet would result in a fatal error as the `_format_version` does not match the specified pattern.
+
+```yaml
+_format_version: "1.0"
+```
+
+```sh
+echo '_format_version: "1.0"' | deck file lint -s - ./docs/lint/version.yaml
+Linting Violations: 1
+Failures: 1
+
+[error][1:18] Validate version 3.1 for decK files: `1.0` does not match the expression `^3.1$`
+```
+
+In order for the decK file to pass the linting validation, the `_format_version` would need to be updated:
+
+```sh
+echo '_format_version: "3.1"' | deck file lint -s - ./docs/lint/version.yaml && echo $?
+0
+```
+
+See the [docs/lint](docs/lint) folder for example rulesets that may provide common APIOps validations you may wish to perform.
+
+---
 ## Example Workflow
 
 ### Transform Pipeline

--- a/docs/lint/https.yaml
+++ b/docs/lint/https.yaml
@@ -1,0 +1,16 @@
+# This example rule will validate a decK file
+# ensuring that all Kong Gateway services
+# utilize https protocol only
+rules:
+  version-check:
+    description: "Ensure https usage in Kong GW Services"
+    # From the root, select all services key
+    given: $.services[*].protocol
+    # Fatal error if rule is violated
+    severity: error
+    then:
+      # Match on a regex pattern for the value selected from
+      # JSON Path in the given field
+      function: pattern
+      functionOptions:
+        match: "^https$"

--- a/docs/lint/version.yaml
+++ b/docs/lint/version.yaml
@@ -1,0 +1,16 @@
+# This example rule will validate the decK file version
+# which is specified in the _format_version key at the root
+# of the document
+rules:
+  version-check:
+    description: "Validate version 3.1 for decK files"
+    # From the root, select the _format_version key
+    given: $._format_version
+    # Fatal error if rule is violated
+    severity: error
+    then:
+      # Match on a regex pattern for the value selected from
+      # JSON Path in the given field
+      function: pattern
+      functionOptions:
+        match: "^3.1$"


### PR DESCRIPTION
This is meant to be a start to some helpful documentation on `deck file lint`.  Ideally we would add some additional use cases in the `docs/lint` folder, building a library of useful rulesets.   For now I just wanted to get some documentation on file somewhere.   Also scheduled is a blog post and some official docs on docs.konghq.com.