### PR TITLE
[openapi2kong] Fix server port parsing

### DIFF
--- a/openapi2kong/oas3_testfiles/04a-servers-upstream.expected.json
+++ b/openapi2kong/oas3_testfiles/04a-servers-upstream.expected.json
@@ -1,0 +1,38 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "server2.com",
+      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
+      "name": "simple-api-overview",
+      "path": "/",
+      "plugins": [],
+      "port": 65000,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "eee036de-517e-59cf-a2e0-17b3adfa31b5",
+          "methods": [
+            "GET"
+          ],
+          "name": "simple-api-overview_opsid",
+          "paths": [
+            "~/$"
+          ],
+          "plugins": [],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_04a-servers-upstream.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_04a-servers-upstream.yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}

--- a/openapi2kong/oas3_testfiles/04a-servers-upstream.yaml
+++ b/openapi2kong/oas3_testfiles/04a-servers-upstream.yaml
@@ -1,0 +1,17 @@
+# properly parses ports, see issue #104
+# https://github.com/Kong/go-apiops/issues/104
+openapi: '3.0.0'
+info:
+  title: Simple API overview
+  version: v2
+servers:
+  - url: https://server2.com:65000/
+paths:
+  /:
+    get:
+      operationId: OpsId
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response

--- a/openapi2kong/service.go
+++ b/openapi2kong/service.go
@@ -230,7 +230,11 @@ func CreateKongService(
 	if service["port"] == nil {
 		if targets[0].Port() != "" {
 			// port is provided, so parse it
-			service["port"], _ = strconv.ParseInt(targets[0].Port(), 10, 16)
+			parsedPort, err := strconv.ParseInt(targets[0].Port(), 10, 64)
+			if err != nil {
+				return nil, nil, err
+			}
+			service["port"] = parsedPort
 		} else {
 			// no port provided, so set it based on scheme, where https/443 is the default
 			if scheme != httpScheme {

--- a/openapi2kong/service.go
+++ b/openapi2kong/service.go
@@ -230,7 +230,7 @@ func CreateKongService(
 	if service["port"] == nil {
 		if targets[0].Port() != "" {
 			// port is provided, so parse it
-			parsedPort, err := strconv.ParseInt(targets[0].Port(), 10, 64)
+			parsedPort, err := strconv.ParseUint(targets[0].Port(), 10, 16)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
https://github.com/Kong/go-apiops/issues/104

This change increases bit size in `strconv.ParseInt` from 16 to 64 to allow higher port numbers. Also previously when the input was unparseable, the error was ignored. Now we can return an error instead of silently setting a potentially incorrect port number.