### PR TITLE
fix(o2k): create leaner config by using service level oidc

### DIFF
--- a/openapi2kong/oas3_testfiles/16-security-oidc-generation.expected.json
+++ b/openapi2kong/oas3_testfiles/16-security-oidc-generation.expected.json
@@ -6,7 +6,20 @@
       "id": "bcda787b-18bc-5f83-85f2-1cf83b5f8eb3",
       "name": "oidc-tests",
       "path": "/",
-      "plugins": [],
+      "plugins": [
+        {
+          "config": {
+            "issuer": "https://konghq.com/top-level",
+            "run_on_preflight": false,
+            "scopes_required": [
+              "scope1",
+              "scope2",
+              "top-scope"
+            ]
+          },
+          "name": "openid-connect"
+        }
+      ],
       "port": 443,
       "protocol": "https",
       "routes": [
@@ -19,20 +32,7 @@
           "paths": [
             "~/path1$"
           ],
-          "plugins": [
-            {
-              "config": {
-                "issuer": "https://konghq.com/top-level",
-                "run_on_preflight": false,
-                "scopes_required": [
-                  "scope1",
-                  "scope2",
-                  "top-scope"
-                ]
-              },
-              "name": "openid-connect"
-            }
-          ],
+          "plugins": [],
           "regex_priority": 200,
           "strip_path": false,
           "tags": [

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -705,6 +705,11 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+		if docOIDCdefaults != nil {
+			// we have OIDC defaults, so we need to add the plugin to the doc-level list
+			pluginConfig, _ := filebasics.Deserialize(docOIDCdefaults)
+			docPluginList = insertPlugin(docPluginList, &pluginConfig)
+		}
 	}
 
 	// Extract the request-validator config from the plugin list
@@ -1017,8 +1022,8 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 				if err != nil {
 					return nil, err
 				}
-				if operationOIDCplugin != nil {
-					// we have OIDC defaults, so we need to add the plugin to the list
+				if string(operationOIDCplugin) != string(docOIDCdefaults) {
+					// we have OIDC config different from the doc-level one, so we need to add the plugin to the Operation
 					pluginConfig, _ := filebasics.Deserialize(operationOIDCplugin)
 					operationPluginList = insertPlugin(operationPluginList, &pluginConfig)
 				}


### PR DESCRIPTION
since oidc is typically authorized at operation level, it was generated per route. But for cases where there is only 1 it would generate many similar configs per path.
Now it creates 1 on the service, and ONLY deviating ones per route