### PR TITLE
feat(namespace): add namespacing paths

### DIFF
--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -101,7 +101,8 @@ the resulting paths '/addressbook/list' and '/cookbook/list' can be exposed with
 colliding.
 
 A "pre-function" plugin will be added to remove the prefix from the path before
-the request is routed to the service.
+the request is routed to the service. If the prefix is matching the 'service.path'
+suffix, then that property is updated, and no plugin is injected.
 `,
 	Args: cobra.NoArgs,
 	RunE: executeNamespace,

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -119,7 +119,7 @@ func init() {
 	namespaceCmd.Flags().StringP("output-file", "o", "-", "output file to write. Use - to write to stdout.")
 	namespaceCmd.Flags().StringP("format", "", string(filebasics.OutputFormatYaml), "output format: "+
 		string(filebasics.OutputFormatJSON)+" or "+string(filebasics.OutputFormatYaml))
-	patchCmd.Flags().StringArrayP("selector", "", []string{},
+	namespaceCmd.Flags().StringArrayP("selector", "", []string{},
 		"json-pointer identifying routes to update (can be specified more than once)")
 	namespaceCmd.Flags().StringP("path", "", "", "the path based namespace to apply")
 }

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -55,9 +55,9 @@ func executeNamespace(cmd *cobra.Command, _ []string) error {
 
 	var pathPrefix string
 	{
-		pathPrefix, err = cmd.Flags().GetString("path")
+		pathPrefix, err = cmd.Flags().GetString("path-prefix")
 		if err != nil {
-			return fmt.Errorf("failed to retrieve '--path' value; %w", err)
+			return fmt.Errorf("failed to retrieve '--path-prefix' value; %w", err)
 		}
 		err = namespace.CheckNamespace(pathPrefix)
 		if err != nil {
@@ -121,5 +121,5 @@ func init() {
 		string(filebasics.OutputFormatJSON)+" or "+string(filebasics.OutputFormatYaml))
 	namespaceCmd.Flags().StringArrayP("selector", "", []string{},
 		"json-pointer identifying routes to update (can be specified more than once)")
-	namespaceCmd.Flags().StringP("path", "", "", "the path based namespace to apply")
+	namespaceCmd.Flags().StringP("path-prefix", "p", "", "the path based namespace to apply")
 }

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -108,6 +108,32 @@ colliding.
 A "pre-function" plugin will be added to remove the prefix from the path before
 the request is routed to the service. If the prefix is matching the 'service.path'
 suffix, then that property is updated, and no plugin is injected.
+
+Example file:
+
+routes:
+- paths:
+  - ~/tracks/system$
+  strip_path: true
+- paths:
+  - ~/list$
+  strip_path: false
+
+namespaced using "--path-prefix=/kong":
+
+routes:
+- paths:
+  - ~/kong/tracks/system$
+  strip_path: true
+- paths:
+  - ~/kong/list$
+  strip_path: false
+  plugins:
+  - name: pre-function
+    config:
+      access:
+      - "local ns='/kong' -- this strips the '/kong' namespace from the path\nlocal <more code here>"
+
 `,
 	Args: cobra.NoArgs,
 	RunE: executeNamespace,

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -59,7 +59,7 @@ func executeNamespace(cmd *cobra.Command, _ []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to retrieve '--path' value; %w", err)
 		}
-		_, err = namespace.CheckNamespace(pathPrefix)
+		err = namespace.CheckNamespace(pathPrefix)
 		if err != nil {
 			return err
 		}

--- a/cmd/namespace.go
+++ b/cmd/namespace.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/kong/go-apiops/deckformat"
+	"github.com/kong/go-apiops/filebasics"
+	"github.com/kong/go-apiops/jsonbasics"
+	"github.com/kong/go-apiops/namespace"
+	"github.com/spf13/cobra"
+)
+
+// Executes the CLI command "namespace"
+func executeNamespace(cmd *cobra.Command, _ []string) error {
+	inputFilename, err := cmd.Flags().GetString("state")
+	if err != nil {
+		return fmt.Errorf("failed getting cli argument 'state'; %w", err)
+	}
+
+	outputFilename, err := cmd.Flags().GetString("output-file")
+	if err != nil {
+		return fmt.Errorf("failed getting cli argument 'output-file'; %w", err)
+	}
+
+	var outputFormat string
+	{
+		outputFormat, err = cmd.Flags().GetString("format")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'format'; %w", err)
+		}
+		outputFormat = strings.ToUpper(outputFormat)
+	}
+
+	var matchPrefix string
+	{
+		matchPrefix, err := cmd.Flags().GetString("prefix")
+		if err != nil {
+			return fmt.Errorf("failed to retrieve '--prefix' value; %w", err)
+		}
+		_, err = namespace.CheckPrefix(matchPrefix)
+		if err != nil {
+			return err
+		}
+	}
+
+	var namespaceStr string
+	{
+		namespaceStr, err = cmd.Flags().GetString("namespace")
+		if err != nil {
+			return fmt.Errorf("failed to retrieve '--namespace' value; %w", err)
+		}
+		_, err = namespace.CheckNamespace(namespaceStr)
+		if err != nil {
+			return err
+		}
+	}
+
+	trackInfo := deckformat.HistoryNewEntry("namespace")
+	trackInfo["input"] = inputFilename
+	trackInfo["output"] = outputFilename
+	trackInfo["prefix"] = matchPrefix
+	trackInfo["namespace"] = namespaceStr
+
+	// do the work; read/prefix/write
+	data, err := filebasics.DeserializeFile(inputFilename)
+	if err != nil {
+		return err
+	}
+
+	yamlNode := jsonbasics.ConvertToYamlNode(data)
+	err = namespace.Apply(yamlNode, matchPrefix, namespaceStr)
+	if err != nil {
+		log.Fatalf("failed to apply the namespace: %s", err)
+	}
+	data = jsonbasics.ConvertToJSONobject(yamlNode)
+
+	deckformat.HistoryAppend(data, trackInfo)
+	return filebasics.WriteSerializedFile(outputFilename, data, filebasics.OutputFormat(outputFormat))
+}
+
+//
+//
+// Define the CLI data for the namespace command
+//
+//
+
+var namespaceCmd = &cobra.Command{
+	Use:   "namespace [flags]",
+	Short: "Namespaces API paths by prefixing it",
+	Long: `Namespaces API paths by prefixing it.
+
+By prefixing paths with a specific segment, colliding paths to services can be
+namespaced to prevent the collisions. Eg. 2 API definitions that both expose a
+'/list' path. By prefixing one with '/addressbook' and the other with '/cookbook'
+the resulting paths '/addressbook/list' and '/cookbook/list' can be exposed without
+colliding.
+
+A "pre-function" plugin will be added to remove the prefix from the path before
+the request is routed to the service.
+`,
+	Args: cobra.NoArgs,
+	RunE: executeNamespace,
+}
+
+func init() {
+	rootCmd.AddCommand(namespaceCmd)
+	namespaceCmd.Flags().StringP("state", "s", "-", "decK file to process. Use - to read from stdin.")
+	namespaceCmd.Flags().StringP("output-file", "o", "-", "output file to write. Use - to write to stdout.")
+	namespaceCmd.Flags().StringP("format", "", string(filebasics.OutputFormatYaml), "output format: "+
+		string(filebasics.OutputFormatJSON)+" or "+string(filebasics.OutputFormatYaml))
+	namespaceCmd.Flags().StringP("prefix", "", "", "the existing path-prefix to match. Only matching paths "+
+		"will be namespaced (plain or regex based)")
+	namespaceCmd.Flags().StringP("namespace", "", "", "the namespace to apply")
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	github.com/vmware-labs/yaml-jsonpath v0.3.2
+	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/term v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -103,13 +103,12 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
-github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
-golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,9 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+golang.org/x/mod v0.13.0 h1:I/DsJXRlw/8l/0c24sM9yb0T4z9liZTduXvdAWYiysY=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -245,11 +245,11 @@ func InjectNamespaceStripping(deckfile *yaml.Node, namespace string,
 
 // GetLuaStripFunction returns the Lua function that strips the namespace from the upstream_uri.
 func GetLuaStripFunction(ns string) string {
-	return `-- this will strip the '` + ns + `' path-namespace from the upstream_uri
-local ns,nst,sn
-ns='` + ns + `'
-nst=ns:sub(-1,-1)=='/' and ns or (ns..'/')
-function sn(u)
+	// code is optimized to be SHORT, not readable. Upon updates only the "namespace" will change
+	// it will be on the first line, so diffs in a gitops pipeline remain easy to grok.
+	return `local ns='` + ns + `' -- this strips the '` + ns + `' namespace from the path
+local nst=ns:sub(-1,-1)=='/' and ns or (ns..'/')
+local function sn(u)
 	local s,e=u:find(nst,1,true)
 	if s then
 		return u:sub(1,s)..u:sub(e+1,-1)

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -118,7 +118,7 @@ func Apply(deckfile *yaml.Node, selectors yamlbasics.SelectorSet, namespace stri
 	var remainder yamlbasics.NodeSet
 	targetRoutes, remainder = allRoutes.Intersection(targetRoutes) // check for non-routes
 	if len(remainder) != 0 {
-		return fmt.Errorf("the selectors returned non-route entities; %w", err)
+		return fmt.Errorf("the selectors returned non-route entities; %d", len(remainder))
 	}
 	if len(targetRoutes) == 0 {
 		logbasics.Info("no routes matched the selectors, nothing to do")

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -323,10 +323,15 @@ func injectServiceNamespaceStripping(service *yaml.Node, namespace string) {
 		}
 	}
 
-	if servicePath != "" && strings.HasSuffix(servicePath, namespace) {
+	namespaceSuffix := namespace
+	if !strings.HasSuffix(namespaceSuffix, "/") {
+		namespaceSuffix = namespaceSuffix + "/"
+	}
+
+	if servicePath != "" && strings.HasSuffix(servicePath, namespaceSuffix) {
 		// if the namespace matches the "tail" of the 'service.path' property, we can strip
 		// it there instead of injecting a plugin.
-		pathNode.Value = strings.TrimSuffix(servicePath, namespace) + "/"
+		pathNode.Value = strings.TrimSuffix(servicePath, namespaceSuffix) + "/"
 	} else {
 		// inject a plugin
 		injectEntityNamespaceStripping(service, namespace)

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -1,0 +1,291 @@
+package namespace
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kong/go-apiops/deckformat"
+	"github.com/kong/go-apiops/filebasics"
+	"github.com/kong/go-apiops/yamlbasics"
+	"gopkg.in/yaml.v3"
+)
+
+// CheckNamespace validates the prefix namespace. Returns updated namespace. Must start with "/",
+// and must have at least 1 character after the "/". If there is no trailing '/', then it will be added.
+func CheckNamespace(prefix string) (string, error) {
+	defaultErr := fmt.Errorf("invalid namespace; the namespace MUST start with '/', "+
+		"and cannot be empty, got: '%s'", prefix)
+
+	if !strings.HasPrefix(prefix, "/") {
+		return "", defaultErr
+	}
+
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
+
+	if len(prefix) <= 2 {
+		return "", defaultErr
+	}
+
+	return prefix, nil
+}
+
+// CheckPrefix validates the prefix argument. Returns updated prefix.
+// Defaults to "", if not specified. Regexes, starting with "~", are not valid.
+func CheckPrefix(prefix string) (string, error) {
+	if prefix == "" {
+		return "", nil
+	}
+
+	if !strings.HasPrefix(prefix, "/") {
+		return "", fmt.Errorf("invalid prefix; the prefix MUST start with '/', got: '%s'", prefix)
+	}
+
+	return prefix, nil
+}
+
+// UpdateSinglePathString updates a single path string with the namespace and returns it.
+func UpdateSinglePathString(path string, prefix string, namespace string) string {
+	strip := "/"
+	if strings.HasPrefix(path, "~") {
+		prefix = "~" + prefix
+		namespace = "~" + namespace
+		strip = "~" + strip
+	}
+	if prefix == "" {
+		// plain path, no prefix to match
+		return namespace + strings.TrimPrefix(path, strip) // prevent double slashes
+	} else if strings.HasPrefix(path, prefix) {
+		return namespace + strings.TrimPrefix(path, strip)
+	}
+
+	return path // unchanged
+}
+
+// UpdateRoute returns true if the route needs stripping the namespace.
+// prefix can be empty (matches all paths).
+// namespace must start with a "/" and end with a "/" (a single "/" is NOT valid).
+func UpdateRoute(route *yaml.Node, prefix string, namespace string) bool {
+	if route.Kind != yaml.MappingNode {
+		return false
+	}
+
+	pathsKeyIdx := yamlbasics.FindFieldKeyIndex(route, "paths")
+	if pathsKeyIdx == -1 {
+		// no "paths" property found. If a prefix was specified, we have a no-match, otherwise we can update
+		// by adding a paths array, and specifying the prefix for Kong to match
+		if prefix != "" {
+			return false
+		}
+
+		// a prefix was specified, but there is no "paths" array, so add one
+		pathsKeyIdx = len(route.Content)
+		yamlbasics.SetFieldValue(route, "paths", yamlbasics.NewArray())
+	}
+
+	pathsArrayNode := route.Content[pathsKeyIdx+1]
+	if pathsArrayNode.Kind != yaml.SequenceNode {
+		return false
+	}
+
+	stripPath := true // the default value
+	stripPathValueNode := yamlbasics.GetFieldValue(route, "strip_path")
+	if stripPathValueNode != nil {
+		stripPath = stripPathValueNode.Value == "true"
+	}
+
+	if len(pathsArrayNode.Content) == 0 {
+		// empty array, add a single entry matching the namespace
+		_ = yamlbasics.Append(pathsArrayNode, yamlbasics.NewString(namespace))
+		return !stripPath
+	}
+
+	// we have a paths-array, now update them all
+	updates := 0
+	for _, pathNode := range pathsArrayNode.Content {
+		updatedPath := UpdateSinglePathString(pathNode.Value, prefix, namespace)
+		if updatedPath != pathNode.Value {
+			pathNode.Value = updatedPath
+			updates++
+		}
+	}
+
+	return updates != 0 && !stripPath
+}
+
+// getAllRoutes returns all route nodes.
+// The result will never be nil, but can be an empty array. The deckfile may be nil.
+func getAllRoutes(deckfile *yaml.Node) []*yaml.Node {
+	return deckformat.GetEntities(deckfile, "routes")
+}
+
+// Apply updates all route entities found within the file with the namespace.
+func Apply(deckfile *yaml.Node, prefixToMatch string, namespace string) error {
+	if deckfile == nil {
+		panic("expected 'deckfile' to be non-nil")
+	}
+	namespace, err := CheckNamespace(namespace)
+	if err != nil {
+		return err
+	}
+	prefixToMatch, err = CheckPrefix(prefixToMatch)
+	if err != nil {
+		return err
+	}
+
+	routesNeedStripping := make([]*yaml.Node, 0)
+	routesNoStripping := make([]*yaml.Node, 0)
+	for _, route := range getAllRoutes(deckfile) {
+		if route.Kind == yaml.MappingNode {
+			if UpdateRoute(route, prefixToMatch, namespace) {
+				routesNeedStripping = append(routesNeedStripping, route)
+			} else {
+				routesNoStripping = append(routesNoStripping, route)
+			}
+		}
+	}
+
+	InjectNamespaceStripping(deckfile, namespace, routesNeedStripping, routesNoStripping)
+
+	return nil
+}
+
+// getAllServices returns all service nodes.
+// The result will never be nil, but can be an empty array. The deckfile may be nil.
+func getAllServices(deckfile *yaml.Node) []*yaml.Node {
+	return deckformat.GetEntities(deckfile, "services")
+}
+
+// findServiceByRoute returns the service node that matches the route.
+// The result will be nil, if no service matches the route.
+func findServiceByRoute(route *yaml.Node, deckfile *yaml.Node) *yaml.Node {
+	if route.Kind != yaml.MappingNode {
+		return nil
+	}
+	allServices := getAllServices(deckfile)
+
+	// walk the services, to find the route as nested entity
+	for _, service := range allServices {
+		if service.Kind != yaml.MappingNode {
+			continue
+		}
+		routeIdx := yamlbasics.FindFieldKeyIndex(service, "routes")
+		if routeIdx == -1 {
+			continue
+		}
+		routes := service.Content[routeIdx+1]
+		if routes.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, routeNode := range routes.Content {
+			if routeNode == route {
+				return service // Found it!
+			}
+		}
+	}
+
+	// Find the service by id or name
+	serviceIdx := yamlbasics.FindFieldKeyIndex(route, "service")
+	if serviceIdx == -1 {
+		return nil // a service-less route
+	}
+	serviceRef := route.Content[serviceIdx+1].Value
+
+	// find by ID
+	for _, service := range allServices {
+		if service.Kind != yaml.MappingNode {
+			continue
+		}
+		idIdx := yamlbasics.FindFieldKeyIndex(service, "id")
+		if idIdx != -1 && service.Content[idIdx+1].Value == serviceRef {
+			return service // Found it by ID!
+		}
+	}
+
+	// find by name
+	for _, service := range allServices {
+		if service.Kind != yaml.MappingNode {
+			continue
+		}
+		nameIdx := yamlbasics.FindFieldKeyIndex(service, "name")
+		if nameIdx != -1 && service.Content[nameIdx+1].Value == serviceRef {
+			return service // Found it by name!
+		}
+	}
+
+	// service specified in the route object, but not found, so it is an inconsistent
+	// file. Report not as not found
+	return nil
+}
+
+// routesNeedStripping, routesNoStripping
+
+// InjectNamespaceStripping injects a namespace stripper into the deckfile.
+// The namespace stripper will remove the namespace from the path, if it matches.
+// updated+unchanged must together be ALL routes in the file!
+func InjectNamespaceStripping(deckfile *yaml.Node, namespace string,
+	routesNeedStripping []*yaml.Node, routesNoStripping []*yaml.Node,
+) {
+	pluginconfig := `{
+		"name": "pre-function",
+		"config": {
+			"access": [
+				"local u,s,e=ngx.var.upstream_uri s,e=u:find('` + namespace + `',1,true)` +
+		`ngx.var.upstream_uri=u:sub(1,s)..u:sub(e+1,-1)"
+			]
+		}
+	}`
+
+	serviceToUpdate := make(map[*yaml.Node][]*yaml.Node) // service -> routes
+	routesToUpdate := make([]*yaml.Node, 0)
+
+	for _, route := range routesNeedStripping {
+		if service := findServiceByRoute(route, deckfile); service != nil {
+			serviceToUpdate[service] = append(serviceToUpdate[service], route)
+		} else {
+			// not attached to a service, so must get its own plugin
+			routesToUpdate = append(routesToUpdate, route)
+		}
+	}
+
+	for _, route := range routesNoStripping {
+		if service := findServiceByRoute(route, deckfile); service != nil {
+			if _, ok := serviceToUpdate[service]; ok {
+				// this service also has routes to strip, so all the routes must individually get the plugin.
+				// move the routes, and remove the service from the "updatable" services map
+				routesToUpdate = append(routesToUpdate, serviceToUpdate[service]...)
+				delete(serviceToUpdate, service)
+			}
+		}
+	}
+
+	// use a new name for the slice to reflect changed use.
+	// routes that need the plugin, service will be added as well
+	entitiesToAddPluginTo := routesToUpdate
+
+	for service := range serviceToUpdate {
+		entitiesToAddPluginTo = append(entitiesToAddPluginTo, service)
+	}
+
+	// inject the plugin into the routes and services
+	for _, entity := range entitiesToAddPluginTo {
+		pluginsIdx := yamlbasics.FindFieldKeyIndex(entity, "plugins")
+		if pluginsIdx == -1 {
+			// no plugins array, add a new array
+			pluginsIdx = len(entity.Content)
+			yamlbasics.SetFieldValue(entity, "plugins", yamlbasics.NewArray())
+		}
+
+		pluginsArrayNode := entity.Content[pluginsIdx+1]
+
+		if pluginsArrayNode.Kind != yaml.SequenceNode {
+			// plugins is not an array, so we cannot add the plugin
+			continue
+		}
+
+		// add the plugin to the array
+		plugin, _ := yamlbasics.FromObject(filebasics.MustDeserialize([]byte(pluginconfig)))
+		_ = yamlbasics.Append(pluginsArrayNode, plugin)
+	}
+}

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -103,7 +103,7 @@ func Apply(deckfile *yaml.Node, selectors yamlbasics.SelectorSet, namespace stri
 		return err
 	}
 
-	allRoutes := deckformat.GetEntities(deckfile, "routes")
+	allRoutes := yamlbasics.NodeSet(deckformat.GetEntities(deckfile, "routes"))
 	var targetRoutes yamlbasics.NodeSet
 	if selectors.IsEmpty() {
 		// no selectors, apply to all routes
@@ -116,7 +116,7 @@ func Apply(deckfile *yaml.Node, selectors yamlbasics.SelectorSet, namespace stri
 		}
 	}
 	var remainder yamlbasics.NodeSet
-	targetRoutes, remainder = yamlbasics.Intersection(allRoutes, targetRoutes) // check for non-routes
+	targetRoutes, remainder = allRoutes.Intersection(targetRoutes) // check for non-routes
 	if len(remainder) != 0 {
 		return fmt.Errorf("the selectors returned non-route entities; %w", err)
 	}
@@ -125,7 +125,7 @@ func Apply(deckfile *yaml.Node, selectors yamlbasics.SelectorSet, namespace stri
 		return nil // nothing to do
 	}
 
-	routesNoStripping := yamlbasics.SubtractSet(allRoutes, targetRoutes) // everything not matched by the selectors
+	routesNoStripping := allRoutes.Subtract(targetRoutes) // everything not matched by the selectors
 	routesNeedStripping := make(yamlbasics.NodeSet, 0)
 	for _, route := range targetRoutes {
 		if UpdateRoute(route, namespace) {

--- a/namespace/namespace_suite_test.go
+++ b/namespace/namespace_suite_test.go
@@ -1,0 +1,13 @@
+package namespace_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNamespace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Namespace Suite")
+}

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -587,6 +587,60 @@ var _ = Describe("Namespace", func() {
 			}`))
 		})
 
+		It("updates service.path, if the namespace matches", func() {
+			data := `{
+				"services": [
+					{
+						"name": "service1",
+						"path": "/somepath` + ns + `",
+						"routes": [
+							{
+								"name": "route1",
+								"strip_path": false,
+								"paths": [
+									"/one"
+								]
+							},{
+								"name": "route2",
+								"strip_path": false,
+								"paths": [
+									"~/xyz/two$"
+								]
+							}
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "", ns) // the "" prefix will match all routes
+
+			Expect(toString(config)).To(MatchJSON(`{
+        "services": [
+          {
+            "name": "service1",
+						"path": "/somepath/",
+            "routes": [
+              {
+                "name": "route1",
+								"strip_path": false,
+                "paths": [
+									"` + ns + `one"
+								]
+              },
+              {
+                "name": "route2",
+								"strip_path": false,
+                "paths": [
+									"~` + ns + `xyz/two$"
+								]
+              }
+            ]
+          }
+        ]
+			}`))
+		})
+
 		It("attaches a plugin to routes, if not all routes match", func() {
 			data := `{
 				"services": [

--- a/namespace/namespace_test.go
+++ b/namespace/namespace_test.go
@@ -1,0 +1,642 @@
+package namespace_test
+
+import (
+	"github.com/kong/go-apiops/namespace"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+func toYaml(data string) *yaml.Node {
+	var yNode yaml.Node
+	err := yaml.Unmarshal([]byte(data), &yNode)
+	if err != nil {
+		panic(err)
+	}
+	return yNode.Content[0] // first entry is the node, yNode is the document
+}
+
+func toString(data *yaml.Node) string {
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+var _ = Describe("Namespace", func() {
+	Describe("CheckNamespace", func() {
+		It("validates a plain namespace", func() {
+			prefix, err := namespace.CheckNamespace("/prefix/")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prefix).To(Equal("/prefix/"))
+		})
+		It("appends a post-fix /", func() {
+			prefix, err := namespace.CheckNamespace("/prefix")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prefix).To(Equal("/prefix/"))
+		})
+		It("rejects a namespace without a leading /", func() {
+			_, err := namespace.CheckNamespace("prefix/")
+			Expect(err).To(HaveOccurred())
+		})
+		It("rejects a namespace with only a leading /", func() {
+			_, err := namespace.CheckNamespace("/")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("CheckPrefix", func() {
+		It("validates a plain prefix", func() {
+			prefix, err := namespace.CheckPrefix("/prefix/")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prefix).To(Equal("/prefix/"))
+		})
+		It("rejects a prefix without a leading /", func() {
+			_, err := namespace.CheckPrefix("prefix/")
+			Expect(err).To(HaveOccurred())
+		})
+		It("rejects a regex prefix with a leading ~", func() {
+			_, err := namespace.CheckPrefix("~/prefix/")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("UpdateSinglePathString", func() {
+		ns, err := namespace.CheckNamespace("/namespace")
+		if err != nil {
+			panic(err)
+		}
+		It("updates plain paths", func() {
+			Expect(namespace.UpdateSinglePathString("/one", "", ns)).To(Equal("/namespace/one"))
+			Expect(namespace.UpdateSinglePathString("/one", "/", ns)).To(Equal("/namespace/one"))
+			Expect(namespace.UpdateSinglePathString("/one", "/one", ns)).To(Equal("/namespace/one"))
+			Expect(namespace.UpdateSinglePathString("/one", "/two", ns)).To(Equal("/one"))
+		})
+		It("updates empty paths", func() {
+			Expect(namespace.UpdateSinglePathString("/", "", ns)).To(Equal("/namespace/"))
+			Expect(namespace.UpdateSinglePathString("/", "/", ns)).To(Equal("/namespace/"))
+			Expect(namespace.UpdateSinglePathString("/", "/one", ns)).To(Equal("/"))
+		})
+		It("updates regex paths", func() {
+			Expect(namespace.UpdateSinglePathString("~/demo/(?<something>[^#?/]+)/else$", "",
+				ns)).To(Equal("~/namespace/demo/(?<something>[^#?/]+)/else$"))
+			Expect(namespace.UpdateSinglePathString("~/demo/(?<something>[^#?/]+)/else$", "/",
+				ns)).To(Equal("~/namespace/demo/(?<something>[^#?/]+)/else$"))
+			Expect(namespace.UpdateSinglePathString("~/demo/(?<something>[^#?/]+)/else$", "/demo",
+				ns)).To(Equal("~/namespace/demo/(?<something>[^#?/]+)/else$"))
+			Expect(namespace.UpdateSinglePathString("~/demo/(?<something>[^#?/]+)/else$", "/two",
+				ns)).To(Equal("~/demo/(?<something>[^#?/]+)/else$"))
+		})
+	})
+
+	Describe("UpdateRoute", func() {
+		ns, err := namespace.CheckNamespace("/namespace")
+		if err != nil {
+			panic(err)
+		}
+
+		Describe("strip_path == true", func() {
+			It("updates plain paths, matching all, no prefix", func() {
+				data := `{
+					"strip_path": true,
+					"paths": [
+						"/one",
+						"/two"
+					]}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": true,
+					"paths": [
+						"/namespace/one",
+						"/namespace/two"
+					]
+				}`))
+				Expect(needsStripping).To(BeFalse())
+			})
+			It("updates plain paths, matching all", func() {
+				data := `{
+					"strip_path": true,
+					"paths": [
+						"/one",
+						"/two"
+					]}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "/", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": true,
+					"paths": [
+							"/namespace/one",
+							"/namespace/two"
+						]
+					}`))
+				Expect(needsStripping).To(BeFalse())
+			})
+			It("updates plain paths, matching some", func() {
+				data := `{
+					"strip_path": true,
+					"paths": [
+						"/one",
+						"/two"
+					]}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "/one", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": true,
+					"paths": [
+						"/namespace/one",
+						"/two"
+					]
+				}`))
+				Expect(needsStripping).To(BeFalse())
+			})
+			It("doesn't update route with no paths, prefix '/'", func() {
+				data := `{
+					"strip_path": true
+				}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "/", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": true
+				}`))
+				Expect(needsStripping).To(BeFalse())
+			})
+			It("updates route with no paths; no prefix", func() {
+				data := `{
+					"strip_path": true
+				}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": true,
+					"paths": [
+						"/namespace/"
+					]
+				}`))
+				Expect(needsStripping).To(BeFalse())
+			})
+		})
+
+		Describe("strip_path == false", func() {
+			It("updates plain paths, matching all, no prefix", func() {
+				data := `{
+					"strip_path": false,
+					"paths": [
+						"/one",
+						"/two"
+					]}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": false,
+					"paths": [
+						"/namespace/one",
+						"/namespace/two"
+					]
+				}`))
+				Expect(needsStripping).To(BeTrue())
+			})
+			It("updates plain paths, matching all", func() {
+				data := `{
+					"strip_path": false,
+					"paths": [
+						"/one",
+						"/two"
+					]}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "/", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": false,
+					"paths": [
+							"/namespace/one",
+							"/namespace/two"
+						]
+					}`))
+				Expect(needsStripping).To(BeTrue())
+			})
+			It("updates plain paths, matching some", func() {
+				data := `{
+					"strip_path": false,
+					"paths": [
+						"/one",
+						"/two"
+					]}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "/one", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": false,
+					"paths": [
+						"/namespace/one",
+						"/two"
+					]
+				}`))
+				Expect(needsStripping).To(BeTrue())
+			})
+			It("doesn't update route with no paths, prefix '/'", func() {
+				data := `{
+					"strip_path": false,
+				}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "/", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": false
+				}`))
+				Expect(needsStripping).To(BeFalse())
+			})
+			It("updates route with no paths; no prefix", func() {
+				data := `{
+					"strip_path": false,
+				}`
+
+				route := toYaml(data)
+				needsStripping := namespace.UpdateRoute(route, "", ns)
+
+				Expect(toString(route)).To(MatchJSON(`{
+					"strip_path": false,
+					"paths": [
+						"/namespace/"
+					]
+				}`))
+				Expect(needsStripping).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Apply", func() {
+		ns := "/my-namespace/"
+		pluginConf := `{
+			"config": {
+				"access": [
+					"local u,s,e=ngx.var.upstream_uri s,e=u:find('` + ns +
+			`',1,true)ngx.var.upstream_uri=u:sub(1,s)..u:sub(e+1,-1)"
+				]
+			},
+			"name": "pre-function"
+		}`
+
+		//
+		// first we check proper conversions, and injection of the plugin
+		//
+
+		It("handles plain and regex (no prefix-match)", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "route1",
+						"strip_path": false,
+						"paths": [
+							"/one",
+							"/two"
+						]
+					},{
+						"name": "route2",
+						"strip_path": false,
+						"paths": [
+							"~/xyz/one$",
+							"~/xyz/two$"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "", ns)
+
+			Expect(toString(config)).To(MatchJSON(`{
+				"routes": [
+					{
+						"name": "route1",
+						"strip_path": false,
+						"paths": [
+							"` + ns + `one",
+							"` + ns + `two"
+						],
+						"plugins": [` + pluginConf + `]
+					},{
+						"name": "route2",
+						"strip_path": false,
+						"paths": [
+							"~` + ns + `xyz/one$",
+							"~` + ns + `xyz/two$"
+						],
+						"plugins": [` + pluginConf + `]
+					}
+				]
+			}`))
+		})
+
+		It("handles routes without paths, strip=true (no prefix-match)", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "routeA",
+						"strip_path": true,
+						"hosts": [
+							"acme-corp.com"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "", ns)
+
+			Expect(toString(config)).To(MatchJSON(`{
+        "routes": [
+          {
+            "name": "routeA",
+						"hosts": [
+							"acme-corp.com"
+						],
+						"strip_path": true,
+            "paths": [
+              "` + ns + `"
+            ]
+          }
+        ]
+			}`))
+		})
+
+		It("handles routes without paths, strip=false (no prefix-match)", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "routeA",
+						"strip_path": false,
+						"hosts": [
+							"acme-corp.com"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "", ns)
+
+			Expect(toString(config)).To(MatchJSON(`{
+        "routes": [
+          {
+            "name": "routeA",
+						"hosts": [
+							"acme-corp.com"
+						],
+						"strip_path": false,
+            "paths": [
+              "` + ns + `"
+            ],
+            "plugins": [` + pluginConf + `]
+          }
+        ]
+			}`))
+		})
+
+		It("handles plain and regex, strip=true (prefix-match = '/')", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "route1",
+						"strip_path": true,
+						"paths": [
+							"/one",
+							"/two"
+						]
+					},{
+						"name": "route2",
+						"strip_path": true,
+						"paths": [
+							"~/xyz/one$",
+							"~/xyz/two$"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "/", ns)
+
+			Expect(toString(config)).To(MatchJSON(`{
+				"routes": [
+					{
+						"name": "route1",
+						"strip_path": true,
+						"paths": [
+							"` + ns + `one",
+							"` + ns + `two"
+						]
+					},
+					{
+						"name": "route2",
+						"strip_path": true,
+						"paths": [
+							"~` + ns + `xyz/one$",
+							"~` + ns + `xyz/two$"
+						]
+					}
+				]
+			}`))
+		})
+
+		It("handles plain and regex, strip=false (prefix-match = '/')", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "route1",
+						"strip_path": false,
+						"paths": [
+							"/one",
+							"/two"
+						]
+					},{
+						"name": "route2",
+						"strip_path": false,
+						"paths": [
+							"~/xyz/one$",
+							"~/xyz/two$"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "/", ns)
+
+			Expect(toString(config)).To(MatchJSON(`{
+				"routes": [
+					{
+						"name": "route1",
+						"strip_path": false,
+						"paths": [
+							"` + ns + `one",
+							"` + ns + `two"
+						],
+						"plugins": [` + pluginConf + `]
+					},
+					{
+						"name": "route2",
+						"strip_path": false,
+						"paths": [
+							"~` + ns + `xyz/one$",
+							"~` + ns + `xyz/two$"
+						],
+						"plugins": [` + pluginConf + `]
+					}
+				]
+			}`))
+		})
+
+		It("doesn't handle routes without paths (prefix-match = '/')", func() {
+			data := `{
+				"routes": [
+					{
+						"name": "routeA",
+						"hosts": [
+							"acme-corp.com"
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "/", ns)
+
+			Expect(toString(config)).To(MatchJSON(`{
+				"routes": [
+					{
+						"name": "routeA",
+						"hosts": [
+							"acme-corp.com"
+						]
+					}
+				]
+			}`))
+		})
+
+		//
+		// check plugin position; on service or route
+		//
+
+		It("attaches a plugin to the service, if all routes match", func() {
+			data := `{
+				"services": [
+					{
+						"name": "service1",
+						"routes": [
+							{
+								"name": "route1",
+								"strip_path": false,
+								"paths": [
+									"/one"
+								]
+							},{
+								"name": "route2",
+								"strip_path": false,
+								"paths": [
+									"~/xyz/two$"
+								]
+							}
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "", ns) // the "" prefix will match all routes
+
+			Expect(toString(config)).To(MatchJSON(`{
+        "services": [
+          {
+            "name": "service1",
+            "routes": [
+              {
+                "name": "route1",
+								"strip_path": false,
+                "paths": [
+									"` + ns + `one"
+								]
+              },
+              {
+                "name": "route2",
+								"strip_path": false,
+                "paths": [
+									"~` + ns + `xyz/two$"
+								]
+              }
+            ],
+						"plugins": [` + pluginConf + `]
+          }
+        ]
+			}`))
+		})
+
+		It("attaches a plugin to routes, if not all routes match", func() {
+			data := `{
+				"services": [
+					{
+						"name": "service1",
+						"routes": [
+							{
+								"name": "routeA",
+								"strip_path": false,
+								"hosts": [
+									"acme-corp.com"
+								]
+							},{
+								"name": "route1",
+								"strip_path": false,
+								"paths": [
+									"/one"
+								]
+							}
+						]
+					}
+				]
+			}`
+
+			config := toYaml(data)
+			namespace.Apply(config, "/", ns) // the "/" prefix will not match routeA
+
+			Expect(toString(config)).To(MatchJSON(`{
+        "services": [
+          {
+            "name": "service1",
+            "routes": [
+              {
+                "name": "routeA",
+								"strip_path": false,
+                "hosts": [
+									"acme-corp.com"
+								]
+              },{
+                "name": "route1",
+								"strip_path": false,
+                "paths": [
+									"` + ns + `one"
+								],
+								"plugins": [` + pluginConf + `]
+              }
+            ]
+          }
+        ]
+			}`))
+		})
+	})
+})


### PR DESCRIPTION
replaces #32 

This one does not rely on gateway features to be added, but uses a pre-functions plugin to strip the added namespace again before proxying. Ugly but works.
Once a proper solution in gateway is in place, we can switch to that (instead of adding the plugin here).

The plugin config generated: https://github.com/Kong/go-apiops/pull/129/files#diff-77a71302fdcf78eb63e7b91cb21a5c04a1eee45dd70789265057526444df380fR248-R263

```
$ go-apiops namespace --help
Namespaces API paths by prefixing it.

By prefixing paths with a specific segment, colliding paths to services can be
namespaced to prevent the collisions. Eg. 2 API definitions that both expose a
'/list' path. By prefixing one with '/addressbook' and the other with '/cookbook'
the resulting paths '/addressbook/list' and '/cookbook/list' can be exposed without
colliding.

A "pre-function" plugin will be added to remove the prefix from the path before
the request is routed to the service. If the prefix is matching the 'service.path'
suffix, then that property is updated, and no plugin is injected.

Example file:

routes:
- paths:
  - ~/tracks/system$
  strip_path: true
- paths:
  - ~/list$
  strip_path: false

namespaced using "--path-prefix=/kong":

routes:
- paths:
  - ~/kong/tracks/system$
  strip_path: true
- paths:
  - ~/kong/list$
  strip_path: false
  plugins:
  - name: pre-function
    config:
      access:
      - "local ns='/kong' -- this strips the '/kong' namespace from the path\nlocal <more code here>"

Usage:
  go-apiops namespace [flags]

Flags:
      --format string          output format: json or yaml (default "yaml")
  -h, --help                   help for namespace
  -o, --output-file string     output file to write. Use - to write to stdout. (default "-")
  -p, --path-prefix string     the path based namespace to apply
      --selector stringArray   json-pointer identifying routes to update (can be specified more than once)
  -s, --state string           decK file to process. Use - to read from stdin. (default "-")

Global Flags:
      --verbose int   this value sets the verbosity level of the log output (higher == more verbose)
```