### PR TITLE
fix(o2k): limit path-param names to 32 chars

### DIFF
--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -1074,7 +1074,12 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 					varName := match[1]
 					// match single segment; '/', '?', and '#' can mark the end of a segment
 					// see https://github.com/OAI/OpenAPI-Specification/issues/291#issuecomment-316593913
-					regexMatch := "(?<" + sanitizeRegexCapture(varName, opts.InsoCompat) + ">[^#?/]+)"
+					captureName := sanitizeRegexCapture(varName, opts.InsoCompat)
+					if len(captureName) >= 32 {
+						return nil, fmt.Errorf("path-parameter name exceeds 32 characters: '%s' (sanitized to '%s')",
+							varName, captureName)
+					}
+					regexMatch := "(?<" + captureName + ">[^#?/]+)"
 					placeHolder := "{" + varName + "}"
 					logbasics.Debug("replacing path parameter", "parameter", placeHolder, "regex", regexMatch)
 					convertedPath = strings.Replace(convertedPath, placeHolder, regexMatch, 1)

--- a/openapi2kong/openapi2kong_test.go
+++ b/openapi2kong/openapi2kong_test.go
@@ -87,3 +87,34 @@ func Test_Openapi2kong_InsoCompat(t *testing.T) {
 		}
 	}
 }
+
+func Test_Openapi2kong_pathParamLength(t *testing.T) {
+	testDataString := `
+openapi: 3.0.3
+info:
+  title: Path parameter test
+  version: v1
+servers:
+  - url: "https://example.com"
+
+paths:
+  /demo/{something-very-long-that-is-way-beyond-the-32-limit}/:
+    get:
+      operationId: opsid
+      parameters:
+        - in: path
+          name: something-very-long-that-is-way-beyond-the-32-limit
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+`
+	_, err := Convert([]byte(testDataString), O2kOptions{})
+	if err == nil {
+		t.Error("Expected error, but got none")
+	} else {
+		assert.Contains(t, err.Error(), "path-parameter name exceeds 32 characters")
+	}
+}


### PR DESCRIPTION
PCRE engines have a limit of 32 characters.

the path-parameter-names need to be predictable, because they might reuse them in other places (request-transformer template for example). So truncation or truncation and replacing the last x-chars with a hash for uniqueness, will not work, since the names become unpredictable.

Then I think the only alternative is to throw an error in OAS2kong, and have the user preprocess them to shorter names, such that they are well informed about the new names in use. More work, but no surprises.