### PR TITLE
fix(o2k): param-explode default true if form style

### DIFF
--- a/openapi2kong/oas3_testfiles/13-request-validator-plugin.expected.json
+++ b/openapi2kong/oas3_testfiles/13-request-validator-plugin.expected.json
@@ -175,7 +175,7 @@
                 "body_schema": "{}",
                 "parameter_schema": [
                   {
-                    "explode": false,
+                    "explode": true,
                     "in": "query",
                     "name": "queryid",
                     "required": true,
@@ -191,7 +191,7 @@
                     "style": "simple"
                   },
                   {
-                    "explode": false,
+                    "explode": true,
                     "in": "cookie",
                     "name": "cookieid",
                     "required": true,

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -48,15 +48,18 @@ func generateParameterSchema(operation *openapi3.Operation, insoCompat bool) []m
 	for _, parameterRef := range parameters {
 		paramValue := parameterRef.Value
 
+		style := getDefaultParamStyle(paramValue.Style, paramValue.In)
+
 		var explode bool
 		if paramValue.Explode == nil {
-			explode = false
+			explode = (style == "form") // default to true for form style, false for all others
 		} else {
 			explode = *paramValue.Explode
 		}
 
 		if paramValue != nil {
 			paramConf := make(map[string]interface{})
+			paramConf["style"] = style
 			paramConf["explode"] = explode
 			paramConf["in"] = paramValue.In
 			if paramValue.In == "path" {
@@ -65,7 +68,6 @@ func generateParameterSchema(operation *openapi3.Operation, insoCompat bool) []m
 				paramConf["name"] = paramValue.Name
 			}
 			paramConf["required"] = paramValue.Required
-			paramConf["style"] = getDefaultParamStyle(paramValue.Style, paramValue.In)
 
 			schema := extractSchema(paramValue.Schema)
 			if schema != "" {

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -48,16 +48,16 @@ func generateParameterSchema(operation *openapi3.Operation, insoCompat bool) []m
 	for _, parameterRef := range parameters {
 		paramValue := parameterRef.Value
 
-		style := getDefaultParamStyle(paramValue.Style, paramValue.In)
-
-		var explode bool
-		if paramValue.Explode == nil {
-			explode = (style == "form") // default to true for form style, false for all others
-		} else {
-			explode = *paramValue.Explode
-		}
-
 		if paramValue != nil {
+			style := getDefaultParamStyle(paramValue.Style, paramValue.In)
+
+			var explode bool
+			if paramValue.Explode == nil {
+				explode = (style == "form") // default to true for form style, false for all others
+			} else {
+				explode = *paramValue.Explode
+			}
+
 			paramConf := make(map[string]interface{})
 			paramConf["style"] = style
 			paramConf["explode"] = explode


### PR DESCRIPTION
"explode" defaulted to false.
When the style is "form" the "explode" default is now true, in all
other cases false.

OAS ref: https://swagger.io/specification/v3/#parameter-object (2nd table in this paragraph)

FTI-6088