### PR TITLE
fix(o2k): plugin sort if inso-compat is enabled

### DIFF
--- a/cmd/openapi2kong.go
+++ b/cmd/openapi2kong.go
@@ -69,11 +69,20 @@ func executeOpenapi2Kong(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	var insoCompatibility bool
+	{
+		insoCompatibility, err = cmd.Flags().GetBool("inso-compatible")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'inso-compatible'; %w", err)
+		}
+	}
+
 	options := openapi2kong.O2kOptions{
 		Tags:                 entityTags,
 		DocName:              docName,
 		OIDC:                 generateSecurity,
 		IgnoreSecurityErrors: ignoreSecurityErrors,
+		InsoCompat:           insoCompatibility,
 	}
 
 	trackInfo := deckformat.HistoryNewEntry("openapi2kong")
@@ -127,4 +136,5 @@ directive from the file)`)
 	openapi2kongCmd.Flags().BoolP("generate-security", "", false, "generate OpenIDConnect plugins from the "+
 		"security directives")
 	openapi2kongCmd.Flags().BoolP("ignore-security-errors", "", false, "ignore errors for unsupported security schemes")
+	openapi2kongCmd.Flags().BoolP("inso-compatible", "", false, "generate the config in an Inso compatible way")
 }

--- a/openapi2kong/oas3_testfiles/09a-plugins-with-consumers.expected.json
+++ b/openapi2kong/oas3_testfiles/09a-plugins-with-consumers.expected.json
@@ -3,20 +3,6 @@
   "plugins": [
     {
       "config": {
-        "message": "The answer to life, the universe, and everything!",
-        "status_code": 403
-      },
-      "consumer": "johndoe2",
-      "id": "aa56031e-7155-599f-a9e9-93e6b271ba58",
-      "name": "request-termination",
-      "route": "simple-api-overview_uses-path-plugin",
-      "tags": [
-        "OAS3_import",
-        "OAS3file_09a-plugins-with-consumers.yaml"
-      ]
-    },
-    {
-      "config": {
         "message": "For a moment, nothing happened. Then, after a second or so, nothing continued to happen.",
         "status_code": 403
       },
@@ -24,6 +10,20 @@
       "id": "ead16074-ccb0-52dd-9f56-4193529e8ffa",
       "name": "request-termination",
       "route": "simple-api-overview_uses-ops-plugin",
+      "tags": [
+        "OAS3_import",
+        "OAS3file_09a-plugins-with-consumers.yaml"
+      ]
+    },
+    {
+      "config": {
+        "message": "The answer to life, the universe, and everything!",
+        "status_code": 403
+      },
+      "consumer": "johndoe2",
+      "id": "aa56031e-7155-599f-a9e9-93e6b271ba58",
+      "name": "request-termination",
+      "route": "simple-api-overview_uses-path-plugin",
       "tags": [
         "OAS3_import",
         "OAS3file_09a-plugins-with-consumers.yaml"


### PR DESCRIPTION
no id is available in inso-compat mode, and a nil-ref would occur. Now the foreign keys are used to sort in deterministic order.

fixes #183 