### PR TITLE
fix: parameter.required field coming as nil

### DIFF
--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -65,7 +65,12 @@ func generateParameterSchema(operation *v3.Operation, insoCompat bool) []map[str
 			} else {
 				paramConf["name"] = parameter.Name
 			}
-			paramConf["required"] = parameter.Required
+
+			if parameter.Required != nil {
+				paramConf["required"] = parameter.Required
+			} else {
+				paramConf["required"] = false
+			}
 
 			schema := extractSchema(parameter.Schema)
 			if schema != "" {


### PR DESCRIPTION
With recent deck changes that attemp to skip
filling defaults before sending to CP, the cmd
deck file openapi2kong had issues with the required field coming up as null, if it was not filled by
the user. With this change, we fill it with
false by default.

Fixes: https://github.com/Kong/go-apiops/issues/203