### PR TITLE
fix: added fix to validate for top-level type in parameter schemas while using oneOf in request-validator plugin.

### DIFF
--- a/openapi2kong/jsonschema.go
+++ b/openapi2kong/jsonschema.go
@@ -52,9 +52,9 @@ func dereferenceSchema(sr *base.SchemaProxy, seenBefore map[string]*base.SchemaP
 // extractSchema will extract a schema, including all sub-schemas/references and
 // return it as a single JSONschema string. All components will be moved under the
 // "#/definitions/" key.
-func extractSchema(s *base.SchemaProxy) string {
+func extractSchema(s *base.SchemaProxy) (string, map[string]interface{}) {
 	if s == nil || s.Schema() == nil {
-		return ""
+		return "", nil
 	}
 
 	seenBefore := make(map[string]*base.SchemaProxy)
@@ -92,5 +92,5 @@ func extractSchema(s *base.SchemaProxy) string {
 
 	result, _ := json.Marshal(finalSchema)
 	// update the $ref values; this is safe because plain " (double-quotes) would be escaped if in actual values
-	return strings.ReplaceAll(string(result), "\"$ref\":\"#/components/schemas/", "\"$ref\":\"#/definitions/")
+	return strings.ReplaceAll(string(result), "\"$ref\":\"#/components/schemas/", "\"$ref\":\"#/definitions/"), finalSchema
 }

--- a/openapi2kong/jsonschema.go
+++ b/openapi2kong/jsonschema.go
@@ -51,7 +51,9 @@ func dereferenceSchema(sr *base.SchemaProxy, seenBefore map[string]*base.SchemaP
 
 // extractSchema will extract a schema, including all sub-schemas/references and
 // return it as a single JSONschema string. All components will be moved under the
-// "#/definitions/" key.
+// "#/definitions/" key. Along with that, it will also return the schema as a
+// map, so that if any further operations or validations need to be done on the schema
+// they could be performed.
 func extractSchema(s *base.SchemaProxy) (string, map[string]interface{}) {
 	if s == nil || s.Schema() == nil {
 		return "", nil

--- a/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.expected.json
+++ b/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.expected.json
@@ -1,0 +1,78 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "backend.com",
+      "id": "730d612d-914b-5fe8-8ead-e6aa654318ef",
+      "name": "example",
+      "path": "/path",
+      "plugins": [],
+      "port": 80,
+      "protocol": "http",
+      "routes": [
+        {
+          "id": "1446ecde-7037-5f9c-8537-8217e2a12bfa",
+          "methods": [
+            "GET"
+          ],
+          "name": "example_params-test_get",
+          "paths": [
+            "~/params/test$"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "body_schema": "{}",
+                "parameter_schema": [
+                  {
+                    "explode": true,
+                    "in": "query",
+                    "name": "queryid",
+                    "required": true,
+                    "schema": "{\"oneOf\":[{\"example\":10,\"type\":\"integer\"},{\"example\":2.5,\"type\":\"number\"}],\"type\":\"number\"}",
+                    "style": "form"
+                  },
+                  {
+                    "explode": false,
+                    "in": "header",
+                    "name": "testHeader",
+                    "required": true,
+                    "schema": "{\"$ref\":\"#/definitions/headerType\",\"definitions\":{\"headerType\":{\"oneOf\":[{\"example\":\"10\",\"type\":\"string\"},{\"example\":2.5,\"type\":\"number\"}],\"type\":\"string\"}}}",
+                    "style": "simple"
+                  },
+                  {
+                    "explode": false,
+                    "in": "header",
+                    "name": "testHeader",
+                    "required": true,
+                    "schema": "{\"$ref\":\"#/definitions/secondHeaderType\",\"definitions\":{\"secondHeaderType\":{\"oneOf\":[{\"example\":\"10\",\"type\":\"string\"},{\"example\":2.5,\"type\":\"number\"}],\"type\":\"string\"}}}",
+                    "style": "simple"
+                  }
+                ],
+                "version": "draft4"
+              },
+              "enabled": true,
+              "id": "8bd60198-9b34-5f0b-9240-4826c7c331a0",
+              "name": "request-validator",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_17-request-validator-plugin-oneOf-usage.yaml"
+              ]
+            }
+          ],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_17-request-validator-plugin-oneOf-usage.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_17-request-validator-plugin-oneOf-usage.yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}

--- a/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.expected.json
+++ b/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.expected.json
@@ -37,15 +37,15 @@
                     "in": "header",
                     "name": "testHeader",
                     "required": true,
-                    "schema": "{\"$ref\":\"#/definitions/headerType\",\"definitions\":{\"headerType\":{\"oneOf\":[{\"example\":\"10\",\"type\":\"string\"},{\"example\":2.5,\"type\":\"number\"}],\"type\":\"string\"}}}",
+                    "schema": "{\"$ref\":\"#/definitions/headerType\",\"definitions\":{\"headerType\":{\"oneOf\":[{\"$ref\":\"#/definitions/stringType\"},{\"$ref\":\"#/definitions/numberType\"}],\"type\":\"string\"},\"numberType\":{\"example\":2.5,\"type\":\"number\"},\"stringType\":{\"example\":\"10\",\"type\":\"string\"}}}",
                     "style": "simple"
                   },
                   {
                     "explode": false,
                     "in": "header",
-                    "name": "testHeader",
+                    "name": "secondTestHeader",
                     "required": true,
-                    "schema": "{\"$ref\":\"#/definitions/secondHeaderType\",\"definitions\":{\"secondHeaderType\":{\"oneOf\":[{\"example\":\"10\",\"type\":\"string\"},{\"example\":2.5,\"type\":\"number\"}],\"type\":\"string\"}}}",
+                    "schema": "{\"$ref\":\"#/definitions/secondHeaderType\",\"definitions\":{\"numberType\":{\"example\":2.5,\"type\":\"number\"},\"secondHeaderType\":{\"oneOf\":[{\"$ref\":\"#/definitions/stringType\"},{\"$ref\":\"#/definitions/numberType\"}],\"type\":\"string\"},\"stringType\":{\"example\":\"10\",\"type\":\"string\"}}}",
                     "style": "simple"
                   }
                 ],

--- a/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.yaml
+++ b/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.yaml
@@ -1,0 +1,53 @@
+# When the request-validator is added without a body or parameter schema
+# the generator should automatically generate it.
+
+openapi: 3.0.2
+
+info:
+  title: Example
+  version: 1.0.0
+
+servers:
+  - url: http://backend.com/path
+
+x-kong-plugin-request-validator: {}
+
+paths:
+  /params/test:
+    get:
+      x-kong-plugin-request-validator:
+        enabled: true
+        config:
+          body_schema: '{}'
+      parameters:
+        - in: query
+          name: queryid
+          schema:
+            type: number
+            oneOf:
+              - type: integer
+                example: 10
+              - type: number
+                example: 2.5
+          required: true
+        - in: header
+          name: testHeader
+          schema:
+            $ref: '#/components/schemas/headerType'
+          required: true
+        - in: header
+          name: testHeader
+          schema:
+            $ref: '#/components/schemas/secondHeaderType'
+          required: true
+components:
+  schemas:
+    headerType:
+      type: string
+      oneOf:
+        - type: string
+          example: "10"
+        - type: number
+          example: 2.5
+    secondHeaderType:
+      $ref: '#/components/schemas/headerType'

--- a/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.yaml
+++ b/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.yaml
@@ -36,7 +36,7 @@ paths:
             $ref: '#/components/schemas/headerType'
           required: true
         - in: header
-          name: testHeader
+          name: secondTestHeader
           schema:
             $ref: '#/components/schemas/secondHeaderType'
           required: true
@@ -45,9 +45,14 @@ components:
     headerType:
       type: string
       oneOf:
-        - type: string
-          example: "10"
-        - type: number
-          example: 2.5
+        - $ref: '#/components/schemas/stringType'
+        - $ref: '#/components/schemas/numberType'
     secondHeaderType:
       $ref: '#/components/schemas/headerType'
+    stringType:
+      type: string
+      example: "10"
+    numberType:
+      type: number
+      example: 2.5
+    

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -1027,8 +1027,12 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 
 			// Extract the request-validator config from the plugin list, generate it and reinsert
 			operationValidatorConfig, operationPluginList = getValidatorPlugin(operationPluginList, pathValidatorConfig)
-			validatorPlugin := generateValidatorPlugin(operationValidatorConfig, operation, pathitem, opts.UUIDNamespace,
+			validatorPlugin, err := generateValidatorPlugin(operationValidatorConfig, operation, pathitem, opts.UUIDNamespace,
 				operationBaseName, opts.SkipID, opts.InsoCompat)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create validator plugin: %w", err)
+			}
+
 			operationPluginList = insertPlugin(operationPluginList, validatorPlugin)
 
 			// construct the route

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -34,7 +34,9 @@ func getDefaultParamStyle(givenStyle string, paramType string) string {
 // generateParameterSchema returns the given schema if there is one, a generated
 // schema if it was specified, or nil if there is none.
 // Parameters include path, query, and headers
-func generateParameterSchema(operation *v3.Operation, path *v3.PathItem, insoCompat bool) ([]map[string]interface{}, error) {
+func generateParameterSchema(operation *v3.Operation, path *v3.PathItem,
+	insoCompat bool,
+) ([]map[string]interface{}, error) {
 	pathParameters := path.Parameters
 	operationParameters := operation.Parameters
 	if pathParameters == nil && operationParameters == nil {

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -97,7 +97,8 @@ func generateParameterSchema(operation *v3.Operation, path *v3.PathItem, insoCom
 
 				_, typeStr, ok := fetchOneOfAndType(schemaMap)
 				if ok && typeStr == "" {
-					return nil, fmt.Errorf(`parameter schemas for request-validator plugin using oneOf must have a top-level type property`)
+					return nil,
+						fmt.Errorf(`parameter schemas for request-validator plugin using oneOf must have a top-level type property`)
 				}
 			}
 

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -308,5 +308,11 @@ func fetchTopLevelType(schemaMap map[string]interface{}) (string, bool) {
 		}
 	}
 
+	if !oneOfFound && !anyOfFound {
+		// We don't need a top-level type for the case where
+		// there is no oneOf or anyOf schema
+		return "", true
+	}
+
 	return "", false
 }


### PR DESCRIPTION
As of now, deck file openapi2kong command was not
checking for multiple types used while creating parameter schemas with oneOf, which is not supported by Kong request- validator plugin. Thus, we are forcing for defining a top-level type property and erroring out in case it is not present.

Fixes: https://github.com/Kong/go-apiops/issues/206