### PR TITLE
fix: validating cookie parameter for req-validator

### DIFF
--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -81,6 +81,12 @@ func generateParameterSchema(operation *v3.Operation, path *v3.PathItem,
 			paramConf["style"] = style
 			paramConf["explode"] = explode
 			paramConf["in"] = parameter.In
+
+			if parameter.In == "cookie" {
+				return nil, fmt.Errorf(`cookie parameters are not supported for request-validator plugin; 
+				choose either path, query or header`)
+			}
+
 			if parameter.In == "path" {
 				paramConf["name"] = sanitizeRegexCapture(parameter.Name, insoCompat)
 			} else {


### PR DESCRIPTION
At the moment, we do not support cookie parameters in request-validator plugin. However, `deck file openapi2kong` command generates the yaml file even if it is present in the parameter schema. Thus, adding a validation layer over it to ensure deck does not create invalid specs.

For: https://github.com/Kong/go-apiops/issues/223