### PR TITLE
fix: fixed mixed-types array generation for req-validator plugin

### DIFF
--- a/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.expected.json
+++ b/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.expected.json
@@ -47,6 +47,22 @@
                     "required": true,
                     "schema": "{\"$ref\":\"#/definitions/secondHeaderType\",\"definitions\":{\"numberType\":{\"example\":2.5,\"type\":\"number\"},\"secondHeaderType\":{\"oneOf\":[{\"$ref\":\"#/definitions/stringType\"},{\"$ref\":\"#/definitions/numberType\"}],\"type\":\"string\"},\"stringType\":{\"example\":\"10\",\"type\":\"string\"}}}",
                     "style": "simple"
+                  },
+                  {
+                    "explode": true,
+                    "in": "query",
+                    "name": "testArrayOne",
+                    "required": true,
+                    "schema": "{\"items\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},\"type\":\"array\"}",
+                    "style": "form"
+                  },
+                  {
+                    "explode": true,
+                    "in": "query",
+                    "name": "testArrayTwo",
+                    "required": true,
+                    "schema": "{\"definitions\":{\"headerType\":{\"oneOf\":[{\"$ref\":\"#/definitions/stringType\"},{\"$ref\":\"#/definitions/numberType\"}],\"type\":\"string\"},\"newType\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"number\"}],\"type\":\"string\"},\"numberType\":{\"example\":2.5,\"type\":\"number\"},\"stringType\":{\"example\":\"10\",\"type\":\"string\"}},\"items\":{\"oneOf\":[{\"$ref\":\"#/definitions/headerType\"},{\"$ref\":\"#/definitions/newType\"}]},\"type\":\"array\"}",
+                    "style": "form"
                   }
                 ],
                 "version": "draft4"

--- a/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.yaml
+++ b/openapi2kong/oas3_testfiles/17-request-validator-plugin-oneOf-usage.yaml
@@ -40,6 +40,24 @@ paths:
           schema:
             $ref: '#/components/schemas/secondHeaderType'
           required: true
+        - in: query
+          name: testArrayOne
+          schema:
+            type: array
+            items:
+              oneOf:
+                - type: string
+                - type: integer
+          required: true
+        - in: query
+          name: testArrayTwo
+          schema:
+            type: array
+            items:
+              oneOf:
+                - $ref: '#/components/schemas/headerType'
+                - $ref: '#/components/schemas/newType'
+          required: true
 components:
   schemas:
     headerType:
@@ -55,4 +73,11 @@ components:
     numberType:
       type: number
       example: 2.5
+    newType:
+      type: string
+      oneOf:
+        - type: string
+        - type: number
+    
+    
     

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -351,5 +351,5 @@ func fetchTopLevelType(schemaMap map[string]interface{}) (string, bool) {
 		return "", false
 	}
 
-	return typeStr, true
+	return "", true
 }


### PR DESCRIPTION
This is related to FTI: https://konghq.atlassian.net/browse/FTI-6357

For: https://github.com/Kong/go-apiops/issues/230