### PR TITLE
feat: add support for ignoring circular refs in OpenAPI spec

### DIFF
--- a/cmd/openapi2kong.go
+++ b/cmd/openapi2kong.go
@@ -77,12 +77,21 @@ func executeOpenapi2Kong(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	var ignoreCircularRefs bool
+	{
+		ignoreCircularRefs, err = cmd.Flags().GetBool("ignore-circular-refs")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'ignore-circular-refs'; %w", err)
+		}
+	}
+
 	options := openapi2kong.O2kOptions{
 		Tags:                 entityTags,
 		DocName:              docName,
 		OIDC:                 generateSecurity,
 		IgnoreSecurityErrors: ignoreSecurityErrors,
 		InsoCompat:           insoCompatibility,
+		IgnoreCircularRefs:   ignoreCircularRefs,
 	}
 
 	trackInfo := deckformat.HistoryNewEntry("openapi2kong")
@@ -137,4 +146,5 @@ directive from the file)`)
 		"security directives")
 	openapi2kongCmd.Flags().BoolP("ignore-security-errors", "", false, "ignore errors for unsupported security schemes")
 	openapi2kongCmd.Flags().BoolP("inso-compatible", "", false, "generate the config in an Inso compatible way")
+	openapi2kongCmd.Flags().BoolP("ignore-circular-refs", "", false, "ignore circular references in the spec")
 }

--- a/openapi2kong/oas3_testfiles/20-ignore-circular-references.circular-yaml
+++ b/openapi2kong/oas3_testfiles/20-ignore-circular-references.circular-yaml
@@ -1,0 +1,68 @@
+openapi: 3.1.0
+info:
+  title: Testing Circular
+  version: 1.1.1
+
+  contact:
+    name: Kong Insomnia
+
+servers:
+  - url: https://some.random.url
+
+x-kong-plugin-request-validator:
+  enabled: true
+  version: draft4
+  config:
+    verbose_response: true
+
+tags:
+  - name: Testing
+    
+paths:
+  "/categories":
+    get:
+      tags:
+      - Category
+      summary: Get all categories for a given classificationId and brand
+      parameters:
+      - name: classificationId
+        in: query
+        description: 'Classification ID. Example value: 545'
+        required: true
+        schema:
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CategoriesResponse"
+components:
+  schemas:
+    CategoriesResponse:
+      required:
+      - categories
+      type: object
+      properties:
+        categories:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Category"
+      additionalProperties: false
+    Category:
+      required:
+      - id
+      - subCategories
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        subCategories:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Category"
+      additionalProperties: false
+    

--- a/openapi2kong/oas3_testfiles/20-ignore-circular-references.expected_no_circular.json
+++ b/openapi2kong/oas3_testfiles/20-ignore-circular-references.expected_no_circular.json
@@ -1,0 +1,63 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "some.random.url",
+      "id": "68804eaf-310b-508e-ae22-fe6a7b9ab716",
+      "name": "testing-circular",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "ce628b39-dec4-5171-a149-df610ebca091",
+          "methods": [
+            "GET"
+          ],
+          "name": "testing-circular_categories_get",
+          "paths": [
+            "~/categories$"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "parameter_schema": [
+                  {
+                    "explode": true,
+                    "in": "query",
+                    "name": "classificationId",
+                    "required": true,
+                    "schema": "{\"format\":\"int32\",\"type\":\"integer\"}",
+                    "style": "form"
+                  }
+                ],
+                "verbose_response": true,
+                "version": "draft4"
+              },
+              "enabled": true,
+              "id": "7ed4fd33-1079-5822-84cf-fcfd81b22dd5",
+              "name": "request-validator",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_20-ignore-circular-references.circular-yaml"
+              ],
+              "version": "draft4"
+            }
+          ],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_20-ignore-circular-references.circular-yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_20-ignore-circular-references.circular-yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}

--- a/openapi2kong/oas3_testfiles/20-ignore-circular-references.generated_no_circular.json
+++ b/openapi2kong/oas3_testfiles/20-ignore-circular-references.generated_no_circular.json
@@ -1,0 +1,63 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "some.random.url",
+      "id": "68804eaf-310b-508e-ae22-fe6a7b9ab716",
+      "name": "testing-circular",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "ce628b39-dec4-5171-a149-df610ebca091",
+          "methods": [
+            "GET"
+          ],
+          "name": "testing-circular_categories_get",
+          "paths": [
+            "~/categories$"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "parameter_schema": [
+                  {
+                    "explode": true,
+                    "in": "query",
+                    "name": "classificationId",
+                    "required": true,
+                    "schema": "{\"format\":\"int32\",\"type\":\"integer\"}",
+                    "style": "form"
+                  }
+                ],
+                "verbose_response": true,
+                "version": "draft4"
+              },
+              "enabled": true,
+              "id": "7ed4fd33-1079-5822-84cf-fcfd81b22dd5",
+              "name": "request-validator",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_20-ignore-circular-references.circular-yaml"
+              ],
+              "version": "draft4"
+            }
+          ],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_20-ignore-circular-references.circular-yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_20-ignore-circular-references.circular-yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-apiops/logbasics"
 	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
 	openapibase "github.com/pb33f/libopenapi/datamodel/high/base"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -45,6 +46,8 @@ type O2kOptions struct {
 	OIDC bool
 	// Ignore security errors (non-OIDC and AND/OR logic)
 	IgnoreSecurityErrors bool
+	// Ignore circular references
+	IgnoreCircularRefs bool
 }
 
 // setDefaults sets the defaults for the OpenAPI2Kong operation.
@@ -614,6 +617,14 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	openapiDoc, err := libopenapi.NewDocument(content)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing OAS3 file: [%w]", err)
+	}
+
+	// Check if circular references must be ignored
+	if opts.IgnoreCircularRefs {
+		docConfig := datamodel.NewDocumentConfiguration()
+		docConfig.IgnoreArrayCircularReferences = true
+		docConfig.IgnorePolymorphicCircularReferences = true
+		openapiDoc.SetConfiguration(docConfig)
 	}
 
 	// var errors []error


### PR DESCRIPTION
Added new flag to ignore circular references in `openapi2kong` subcommand.
In some cases, circular references may actually be valid use cases for a particular specification design.
See https://pb33f.io/libopenapi/circular-references/ for more details.