### PR TITLE
fix: fixed req-validator config generation when both body and param schema are empty.

### DIFF
--- a/openapi2kong/oas3_testfiles/14-no-request-validator-plugin.yaml
+++ b/openapi2kong/oas3_testfiles/14-no-request-validator-plugin.yaml
@@ -19,6 +19,15 @@ paths:
       # there is nothing to validate here, so no plugin should be created
       summary: Get help
       operationId: getHelp
+      parameters:
+        # This would not be added to the req-validator plugin config
+        # as cookie type is not supported yet.
+        # A warning would be logged and this parameter would be ignored.
+        - in: cookie
+          name: cookieid
+          schema:
+            type: integer
+          required: true
       responses:
         '200':
           description: This is a success.

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -227,7 +227,7 @@ func generateValidatorPlugin(operationConfigJSON []byte, operation *v3.Operation
 		if err != nil {
 			return nil, err
 		}
-		if parameterSchema != nil {
+		if len(parameterSchema) != 0 {
 			config["parameter_schema"] = parameterSchema
 			config["version"] = JSONSchemaVersion
 		}


### PR DESCRIPTION
In the above case, we wish to skip the config
generation. Due to improper checking of the
generated parameter schema, it was not
getting assigned nil, as it is supposed to.

This change corrects the check to length
based-checking and improved the test to
validate the same.

For: https://github.com/Kong/go-apiops/issues/241