### PR TITLE
feat: using env vars for format_version string in deck files

### DIFF
--- a/merge/merge.go
+++ b/merge/merge.go
@@ -10,6 +10,10 @@ import (
 	"github.com/kong/go-apiops/logbasics"
 )
 
+const (
+	envVarPrefix = "DECK_"
+)
+
 func merge2Files(data1 map[string]interface{}, data2 map[string]interface{}) map[string]interface{} {
 	mergedData := make(map[string]interface{})
 
@@ -98,6 +102,12 @@ func preprocessFormatVersion(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("invalid environment variable format")
 	}
 	envVarName := formatVersionLine[envStart : envStart+envEnd]
+
+	if !strings.HasPrefix(envVarName, envVarPrefix) {
+		return nil, fmt.Errorf("environment variables in the state file must "+
+			"be prefixed with '%s', found: '%s'", envVarPrefix, envVarName)
+	}
+
 	value := os.Getenv(envVarName)
 	if value == "" {
 		return nil, fmt.Errorf("environment variable '%s' is not set", envVarName)

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -211,5 +211,15 @@ var _ = Describe("Merge", func() {
 
 			validateMerge(fileList, expected, expectErr, nil)
 		})
+
+		It("env variables in _format_version: bad env variable", func() {
+			fileList := []string{
+				"./merge_testfiles/badenvvar.yml",
+			}
+			expected := "environment variables in the state file must be prefixed with 'DECK_', found: 'FORMAT_VERSION'"
+			expectErr := true
+
+			validateMerge(fileList, expected, expectErr, nil)
+		})
 	})
 })

--- a/merge/merge_test.go
+++ b/merge/merge_test.go
@@ -2,6 +2,7 @@ package merge_test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	. "github.com/kong/go-apiops/filebasics"
@@ -141,6 +142,74 @@ var _ = Describe("Merge", func() {
 				merge.MustFiles([]string{"bad_file1.yml", "bad_file2.yml"})
 			}
 			Expect(t).Should(Panic())
+		})
+	})
+
+	Describe("MergeFiles with env variables", func() {
+		It("env variables in configuration", func() {
+			// This tests the order of the resulting file, but also the version of the
+			// final file
+			fileList := []string{
+				"./merge_testfiles/file4.yml",
+				"./merge_testfiles/file5.yml",
+			}
+			expected := "test3_expected.json"
+			expectErr := false
+			expectedHist := []interface{}{
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file4.yml",
+				},
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file5.yml",
+				},
+			}
+
+			validateMerge(fileList, expected, expectErr, expectedHist)
+		})
+
+		It("env variables in _format_version: compatible", func() {
+			os.Setenv("DECK_FORMAT_VERSION", "3.0")
+			fileList := []string{
+				"./merge_testfiles/file6.yml",
+				"./merge_testfiles/file7.yml",
+			}
+			expected := "test4_expected.json"
+			expectErr := false
+			expectedHist := []interface{}{
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file6.yml",
+				},
+				map[string]interface{}{
+					"filename": "./merge_testfiles/file7.yml",
+				},
+			}
+
+			validateMerge(fileList, expected, expectErr, expectedHist)
+		})
+
+		It("env variables in _format_version: incompatible", func() {
+			os.Setenv("DECK_FORMAT_VERSION", "3.0")
+			fileList := []string{
+				"./merge_testfiles/file6.yml",
+				"./merge_testfiles/badversion.yml",
+			}
+			expected := "failed to merge ./merge_testfiles/badversion.yml: files are incompatible; " +
+				"major versions are incompatible; 3.0 and 1.0"
+			expectErr := true
+
+			validateMerge(fileList, expected, expectErr, nil)
+		})
+
+		It("env variables in _format_version: missing env variable", func() {
+			os.Unsetenv("DECK_FORMAT_VERSION")
+			fileList := []string{
+				"./merge_testfiles/file6.yml",
+				"./merge_testfiles/file7.yml",
+			}
+			expected := "environment variable 'DECK_FORMAT_VERSION' is not set"
+			expectErr := true
+
+			validateMerge(fileList, expected, expectErr, nil)
 		})
 	})
 })

--- a/merge/merge_testfiles/badenvvar.yml
+++ b/merge/merge_testfiles/badenvvar.yml
@@ -1,0 +1,2 @@
+# we require format versions to be prefixed with DECK_
+_format_version: "${{ env "FORMAT_VERSION" }}"

--- a/merge/merge_testfiles/file4.yml
+++ b/merge/merge_testfiles/file4.yml
@@ -1,0 +1,12 @@
+_comment: this is file4
+
+_format_version: "3.0"
+
+services:
+- connect_timeout: ${{ env "DECK_SVC_CONNECT_TIMEOUT" }}
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: ${{ env "DECK_SVC_READ_TIMEOUT" }}
+  retries: ${{ env "DECK_SVC_RETRIES" }}

--- a/merge/merge_testfiles/file5.yml
+++ b/merge/merge_testfiles/file5.yml
@@ -1,0 +1,12 @@
+_comment: this is file5
+
+_format_version: "3.0"
+
+services:
+- connect_timeout: ${{ env "DECK_SVC_CONNECT_TIMEOUT" }}
+  host: mockbin.org
+  name: svc2
+  port: 80
+  protocol: http
+  read_timeout: ${{ env "DECK_SVC_READ_TIMEOUT" }}
+  retries: ${{ env "DECK_SVC_RETRIES" }}

--- a/merge/merge_testfiles/file6.yml
+++ b/merge/merge_testfiles/file6.yml
@@ -1,0 +1,12 @@
+_comment: this is file6
+
+_format_version: "${{ env "DECK_FORMAT_VERSION" }}"
+
+services:
+- connect_timeout: ${{ env "DECK_SVC_CONNECT_TIMEOUT" }}
+  host: mockbin.org
+  name: svc1
+  port: 80
+  protocol: http
+  read_timeout: ${{ env "DECK_SVC_READ_TIMEOUT" }}
+  retries: ${{ env "DECK_SVC_RETRIES" }}

--- a/merge/merge_testfiles/file7.yml
+++ b/merge/merge_testfiles/file7.yml
@@ -1,0 +1,12 @@
+_comment: this is file7
+
+_format_version: "${{ env "DECK_FORMAT_VERSION" }}"
+
+services:
+- connect_timeout: ${{ env "DECK_SVC_CONNECT_TIMEOUT" }}
+  host: mockbin.org
+  name: svc2
+  port: 80
+  protocol: http
+  read_timeout: ${{ env "DECK_SVC_READ_TIMEOUT" }}
+  retries: ${{ env "DECK_SVC_RETRIES" }}

--- a/merge/merge_testfiles/test3_expected.json
+++ b/merge/merge_testfiles/test3_expected.json
@@ -1,0 +1,24 @@
+{
+    "_comment": "this is file5",
+    "_format_version": "3.0",
+    "services": [
+      {
+        "connect_timeout": "${{ env \"DECK_SVC_CONNECT_TIMEOUT\" }}",
+        "host": "mockbin.org",
+        "name": "svc1",
+        "port": 80,
+        "protocol": "http",
+        "read_timeout": "${{ env \"DECK_SVC_READ_TIMEOUT\" }}",
+        "retries": "${{ env \"DECK_SVC_RETRIES\" }}"
+      },
+      {
+        "connect_timeout": "${{ env \"DECK_SVC_CONNECT_TIMEOUT\" }}",
+        "host": "mockbin.org",
+        "name": "svc2",
+        "port": 80,
+        "protocol": "http",
+        "read_timeout": "${{ env \"DECK_SVC_READ_TIMEOUT\" }}",
+        "retries": "${{ env \"DECK_SVC_RETRIES\" }}"
+      }
+    ]
+  }

--- a/merge/merge_testfiles/test4_expected.json
+++ b/merge/merge_testfiles/test4_expected.json
@@ -1,0 +1,24 @@
+{
+    "_comment": "this is file7",
+    "_format_version": "3.0",
+    "services": [
+      {
+        "connect_timeout": "${{ env \"DECK_SVC_CONNECT_TIMEOUT\" }}",
+        "host": "mockbin.org",
+        "name": "svc1",
+        "port": 80,
+        "protocol": "http",
+        "read_timeout": "${{ env \"DECK_SVC_READ_TIMEOUT\" }}",
+        "retries": "${{ env \"DECK_SVC_RETRIES\" }}"
+      },
+      {
+        "connect_timeout": "${{ env \"DECK_SVC_CONNECT_TIMEOUT\" }}",
+        "host": "mockbin.org",
+        "name": "svc2",
+        "port": 80,
+        "protocol": "http",
+        "read_timeout": "${{ env \"DECK_SVC_READ_TIMEOUT\" }}",
+        "retries": "${{ env \"DECK_SVC_RETRIES\" }}"
+      }
+    ]
+  }


### PR DESCRIPTION
For https://github.com/Kong/deck/issues/1575
Linked FTI: https://konghq.atlassian.net/browse/FTI-6578

Deck supports [env variables](https://docs.konghq.com/deck/gateway/sensitive-data/#using-deck-environment-variables).

I checked and the following yaml file is accepted by deck sync:

```
_format_version: "${{ env "DECK_FORMAT_VERSION" }}"
services:
- connect_timeout: 60000
  id: 58076db2-28b6-423b-ba39-a797193017f7
  host: mockbin.org
  name: svc1
  port: 80
  protocol: http
  read_timeout: 60000
  retries: 5
```
_Note: Remember the outer quotes ““ to ensure you are passing a string value to _format_version_
_Deck internally parses it as a string but yaml can parse it as int._

As of now, deck file merge command is not accepting environment variable in the format version string 
but other commands (sync, diff, apply, validate, file validate) are working fine.

This PR extends the environment variable substitution logic to work with
merge command for the _format_version string.
Since the merge command requires the _format_version value to check for
compatibility between files, we will ensure that the variable can be retrieved from os.