### PR TITLE
fix openapi2kong: fail with error if no `.paths`

### DIFF
--- a/openapi2kong/oas3_testfiles/20-empty-paths.expected.json
+++ b/openapi2kong/oas3_testfiles/20-empty-paths.expected.json
@@ -1,0 +1,45 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "simple-api-overview.upstream",
+      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
+      "name": "simple-api-overview",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_20-empty-paths.yaml"
+      ]
+    }
+  ],
+  "upstreams": [
+    {
+      "id": "811c42d6-ef18-5296-a550-7dca2262b4d8",
+      "name": "simple-api-overview.upstream",
+      "tags": [
+        "OAS3_import",
+        "OAS3file_20-empty-paths.yaml"
+      ],
+      "targets": [
+        {
+          "tags": [
+            "OAS3_import",
+            "OAS3file_20-empty-paths.yaml"
+          ],
+          "target": "server1.com:443"
+        },
+        {
+          "tags": [
+            "OAS3_import",
+            "OAS3file_20-empty-paths.yaml"
+          ],
+          "target": "server2.com:443"
+        }
+      ]
+    }
+  ]
+}

--- a/openapi2kong/oas3_testfiles/20-empty-paths.yaml
+++ b/openapi2kong/oas3_testfiles/20-empty-paths.yaml
@@ -1,0 +1,10 @@
+# openapi2kong.go should not fail when .paths is empty
+
+openapi: '3.0.0'
+info:
+  title: Simple API overview
+  version: v2
+servers:
+  - url: https://server1.com/
+  - url: https://server2.com/
+paths: []

--- a/openapi2kong/oas3_testfiles/invalid/no-paths.yaml
+++ b/openapi2kong/oas3_testfiles/invalid/no-paths.yaml
@@ -1,0 +1,8 @@
+# openapi2kong.go should fail with an actionable error message when .paths is missing
+
+openapi: '3.0.0'
+info:
+  title: Simple API overview
+  version: v2
+servers:
+  - url: https://server1.com/

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -713,6 +713,11 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	//
 	//
 
+	if doc.Paths == nil {
+		return nil, fmt.Errorf("must have `.paths` in the root of the document. " +
+			"See examples https://github.com/Kong/go-apiops/tree/main/docs")
+	}
+
 	// create a sorted array of paths, to be deterministic in our output order
 	allPaths := doc.Paths.PathItems
 	sortedPaths := make([]string, allPaths.Len())


### PR DESCRIPTION
in OpenAPI spec (OAS) YAML doc. Allow empty `.paths`.

Currently an OAS doc like this

```yaml
---
openapi: 3.0.0

info:
  description: Hendrix AI Gateway
  version: 1.0.0
  title: Hendrix AI Gateway

servers:
- url: https://api.openai.com
```

results in a panic.

```bash
$ deck file openapi2kong --spec oas.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1010e5944]

goroutine 1 [running]:
github.com/kong/go-apiops/openapi2kong.Convert({0x14000572000, 0x4ea, 0x4eb}, {{0x0, 0x0, 0x0}, {0x0, 0x0}, {0x6b, 0xa7, ...}, ...})
	github.com/kong/go-apiops@v0.1.41/openapi2kong/openapi2kong.go:717 +0xfe4
github.com/kong/deck/cmd.executeOpenapi2Kong(0x140001a4d00?, {0x14000238fc0?, 0x4?, 0x1011631d0?})
	github.com/kong/deck/cmd/file_openapi2kong.go:61 +0x3f4
github.com/spf13/cobra.(*Command).execute(0x14000365208, {0x14000238fa0, 0x2, 0x2})
	github.com/spf13/cobra@v1.8.1/command.go:985 +0x834
github.com/spf13/cobra.(*Command).ExecuteC(0x140000a8008)
	github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.8.1/command.go:1034
github.com/kong/deck/cmd.Execute({0x1018414f0, 0x1400035ee10})
	github.com/kong/deck/cmd/root.go:274 +0x64
main.main()
	github.com/kong/deck/main.go:31 +0x20
```

This change makes the command exit with an actionable error message instead.

```bash
$ ./go-apiops openapi2kong --spec oas.yaml

Error: failed converting OpenAPI spec '/Users/dxia/src/ghe.spotify.net/hendrix/ai-gateway/oas.yaml'; must have `.paths` in the root of the document. See examples https://github.com/Kong/go-apiops/tree/main/docs
Usage:
  go-apiops openapi2kong [flags]

...
```