### PR TITLE
Fix: use nullable to allow empty path param

### DIFF
--- a/openapi2kong/oas3_testfiles/21-nullable-path-param.expected.json
+++ b/openapi2kong/oas3_testfiles/21-nullable-path-param.expected.json
@@ -1,0 +1,55 @@
+{
+    "_format_version": "3.0",
+    "services": [
+      {
+        "host": "backend.com",
+        "id": "aac33fce-7ade-5b69-9249-97bea965698e",
+        "name": "odata-style-api-with-nullable-path-params",
+        "path": "/path",
+        "plugins": [],
+        "port": 80,
+        "protocol": "http",
+        "routes": [
+          {
+            "id": "649b2718-47a3-57ec-aec0-b8a4f1bf010d",
+            "methods": [
+              "GET"
+            ],
+            "name": "odata-style-api-with-nullable-path-params_customproductdata",
+            "paths": [
+              "~/CustomWarehouseData\\(Warehouse='(?\u003cwarehouse\u003e[^#?/]*)',Product='(?\u003cproduct\u003e[^#?/]+)'\\)$"
+            ],
+            "plugins": [],
+            "regex_priority": 100,
+            "strip_path": false,
+            "tags": [
+              "OAS3_import",
+              "OAS3file_21-nullable-path-param.yaml"
+            ]
+          },
+          {
+            "id": "dd39d9e0-196d-509d-b141-13e77ce94f81",
+            "methods": [
+              "GET"
+            ],
+            "name": "odata-style-api-with-nullable-path-params_customdata",
+            "paths": [
+              "~/custom/(?\u003ccustomid\u003e[^#?/]+)$"
+            ],
+            "plugins": [],
+            "regex_priority": 100,
+            "strip_path": false,
+            "tags": [
+              "OAS3_import",
+              "OAS3file_21-nullable-path-param.yaml"
+            ]
+          }
+        ],
+        "tags": [
+          "OAS3_import",
+          "OAS3file_21-nullable-path-param.yaml"
+        ]
+      }
+    ],
+    "upstreams": []
+  }

--- a/openapi2kong/oas3_testfiles/21-nullable-path-param.expected.json
+++ b/openapi2kong/oas3_testfiles/21-nullable-path-param.expected.json
@@ -17,7 +17,7 @@
             ],
             "name": "odata-style-api-with-nullable-path-params_customproductdata",
             "paths": [
-              "~/CustomWarehouseData\\(Warehouse='(?\u003cwarehouse\u003e[^#?/]*)',Product='(?\u003cproduct\u003e[^#?/]+)'\\)$"
+              "~/CustomWarehouseData\\(Warehouse='(?\u003cwarehouse\u003e[^#?/]*)',Product='(?\u003cproduct\u003e[^#?/]+)',Location='(?\u003clocation\u003e[^#?/]*)'\\)$"
             ],
             "plugins": [],
             "regex_priority": 100,
@@ -52,4 +52,4 @@
       }
     ],
     "upstreams": []
-  }
+}

--- a/openapi2kong/oas3_testfiles/21-nullable-path-param.yaml
+++ b/openapi2kong/oas3_testfiles/21-nullable-path-param.yaml
@@ -25,7 +25,7 @@ paths:
         4XX:
           description: all 4XX errors
       operationId: customdata
-  ? "/CustomWarehouseData(Warehouse='{Warehouse}',Product='{Product}')"
+  ? "/CustomWarehouseData(Warehouse='{Warehouse}',Product='{Product}',Location='{Location}')"
   : parameters:
       - name: Warehouse
         in: path
@@ -42,8 +42,24 @@ paths:
         schema:
           type: string
           maxLength: 40
+      - name: Location
+        in: path
+        required: true
+        description: Product Number
+        schema:
+          type: string
+          maxLength: 40
     get:
-      summary: List entities from Warehouse based on product ID and warehouse ID
+      summary: List entities from Warehouse based on product ID, location and warehouse ID
+      parameters:
+        - name: Location #overrides the param defined in path level
+          in: path
+          required: true
+          description: Product Number
+          schema:
+            type: string
+            maxLength: 40
+            nullable: true
       tags:
         - WarehouseProductData
       responses:

--- a/openapi2kong/oas3_testfiles/21-nullable-path-param.yaml
+++ b/openapi2kong/oas3_testfiles/21-nullable-path-param.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: OData style API with nullable path params
+  version: 0.0.1
+servers:
+  - url: http://backend.com/path
+paths:
+  /custom/{customId}:
+    parameters:
+      - name: customId
+        in: path
+        required: true
+        description: Custom ID
+        schema:
+          type: string
+          maxLength: 4
+    get:
+      summary: Read the custom information
+      description: Read the custom information of the API
+      tags:
+        - Metadata
+      responses:
+        "200":
+          description: Retrieved metadata
+        4XX:
+          description: all 4XX errors
+      operationId: customdata
+  ? "/CustomWarehouseData(Warehouse='{Warehouse}',Product='{Product}')"
+  : parameters:
+      - name: Warehouse
+        in: path
+        required: true
+        description: ID of warehouse
+        schema:
+          type: string
+          maxLength: 4
+          nullable: true
+      - name: Product
+        in: path
+        required: true
+        description: Product Number
+        schema:
+          type: string
+          maxLength: 40
+    get:
+      summary: List entities from Warehouse based on product ID and warehouse ID
+      tags:
+        - WarehouseProductData
+      responses:
+        "200":
+          description: Retrieved product entities
+        4XX:
+          description: all 4XX errors
+      operationId: customproductdata

--- a/openapi2kong/oas3_testfiles/21-nullable-path-param.yaml
+++ b/openapi2kong/oas3_testfiles/21-nullable-path-param.yaml
@@ -34,7 +34,7 @@ paths:
         schema:
           type: string
           maxLength: 4
-          nullable: true
+          minLength: 0
       - name: Product
         in: path
         required: true
@@ -59,7 +59,7 @@ paths:
           schema:
             type: string
             maxLength: 40
-            nullable: true
+            minLength: 0
       tags:
         - WarehouseProductData
       responses:

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -1100,8 +1100,8 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 					}
 					regexMatch := "(?<" + captureName + ">[^#?/]+)"
 					paramSchema := findParameterSchema(operation.Parameters, pathitem.Parameters, varName)
-					// Check if the parameter is nullable, if so allow empty string as value.
-					if paramSchema != nil && paramSchema.Nullable != nil && *paramSchema.Nullable {
+					// Check if the parameter has a minLength defined, if 0, allow empty string
+					if paramSchema != nil && paramSchema.MinLength != nil && *paramSchema.MinLength == 0 {
 						regexMatch = "(?<" + captureName + ">[^#?/]*)"
 					}
 					placeHolder := "{" + varName + "}"

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -522,7 +522,6 @@ func getForeignKeyPlugins(
 }
 
 // findPathParamSchema returns the Schema for given path parameter name
-// TODO: see if there is a faster way
 func findPathParamSchema(parameters []*v3.Parameter, paramName string) *openapibase.Schema {
 	for _, param := range parameters {
 		if param.Name == paramName {
@@ -1090,10 +1089,8 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 							varName, captureName)
 					}
 
-					var regexMatch string = "(?<" + captureName + ">[^#?/]+)"
-
-					var paramSchema = findPathParamSchema(pathitem.Parameters, varName)
-
+					regexMatch := "(?<" + captureName + ">[^#?/]+)"
+					paramSchema := findPathParamSchema(pathitem.Parameters, varName)
 					// Check if the parameter is nullable, if so allow empty string as value.
 					if paramSchema != nil && paramSchema.Nullable != nil && *paramSchema.Nullable {
 						regexMatch = "(?<" + captureName + ">[^#?/]*)"

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -528,7 +528,6 @@ func findPathParamSchema(parameters []*v3.Parameter, paramName string) *openapib
 			return param.Schema.Schema()
 		}
 	}
-
 	return nil
 }
 
@@ -1088,14 +1087,12 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 						return nil, fmt.Errorf("path-parameter name exceeds 32 characters: '%s' (sanitized to '%s')",
 							varName, captureName)
 					}
-
 					regexMatch := "(?<" + captureName + ">[^#?/]+)"
 					paramSchema := findPathParamSchema(pathitem.Parameters, varName)
 					// Check if the parameter is nullable, if so allow empty string as value.
 					if paramSchema != nil && paramSchema.Nullable != nil && *paramSchema.Nullable {
 						regexMatch = "(?<" + captureName + ">[^#?/]*)"
 					}
-
 					placeHolder := "{" + varName + "}"
 					logbasics.Debug("replacing path parameter", "parameter", placeHolder, "regex", regexMatch)
 					convertedPath = strings.Replace(convertedPath, placeHolder, regexMatch, 1)


### PR DESCRIPTION
In this PR, we are introducing conditional step for allowing empty string as path param.

We have reports from customers where the regex `[^#?/]+` for parameters leads routing to 404 when a parameter is empty string, so when a parameter has `minLength` set to 0, we will use `[^#?/]*` instead.
Path parameters are mandatory in OpenAPI spec, and cannot be empty - however, when customers have [OData](https://www.odata.org/documentation/odata-version-2-0/uri-conventions/) style apis, empty string could be valid.

Fixes https://github.com/Kong/go-apiops/issues/269, https://konghq.atlassian.net/browse/FTI-6687
Discussion for using minLength - https://konghq.atlassian.net/browse/FTI-6687?focusedCommentId=165300
