### PR TITLE
fix: no service gen if no servers are present.

### DIFF
--- a/openapi2kong/oas3_testfiles/23-no-servers-at-all.expected.json
+++ b/openapi2kong/oas3_testfiles/23-no-servers-at-all.expected.json
@@ -1,0 +1,38 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "localhost",
+      "id": "a49d53c1-c2ce-5d7c-a72c-e2c376de9e93",
+      "name": "simple-api",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "046fbd3e-5b29-5d21-b7dd-637c5b1060df",
+          "methods": [
+            "GET"
+          ],
+          "name": "simple-api_hello_get",
+          "paths": [
+            "~/hello$"
+          ],
+          "plugins": [],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_23-no-servers-at-all.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_23-no-servers-at-all.yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}

--- a/openapi2kong/oas3_testfiles/23-no-servers-at-all.yaml
+++ b/openapi2kong/oas3_testfiles/23-no-servers-at-all.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+  version: 1.0.0
+paths:
+  /hello:
+    get:
+      summary: Say Hello
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Hello, world!

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -542,7 +542,9 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	upstreams := make([]interface{}, 0)
 
 	var (
-		err            error
+		err              error
+		removeDocService bool // set to true if no docServers are present;
+		// it's used in case services is empty
 		doc            v3.Document             // the OAS3 document we're operating on
 		kongComponents *map[string]interface{} // contents of OAS key `/components/x-kong/`
 		kongTags       []string                // tags to attach to Kong entities
@@ -670,12 +672,19 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("failed to create service/upstream from document root: %w", err)
 	}
 
+	services = append(services, docService)
 	// if there are no document-level servers defined
-	// we are skipping to add the default created docService
+	// we want to skip adding the default created docService
 	// in the services slice. This is done to ensure that
 	// an unintended extra service is not created.
-	if len(docServers) != 0 {
-		services = append(services, docService)
+	// However, if there are no servers defined, anywhere
+	// else in the document, we still want to
+	// create the default docService, so as to not return
+	// an empty services array.
+	// If there are other servers defined, we will
+	// remove the docService from the services slice in the end.
+	if len(docServers) == 0 {
+		removeDocService = true
 	}
 	if docUpstream != nil {
 		upstreams = append(upstreams, docUpstream)
@@ -1121,7 +1130,12 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	}
 
 	// export arrays with services, upstreams, and plugins to the final object
-	result["services"] = services
+	if len(services) > 1 && removeDocService {
+		// we have more than one service, and the docService is not needed, so remove it
+		result["services"] = services[1:]
+	} else {
+		result["services"] = services
+	}
 	result["upstreams"] = upstreams
 	if len(*foreignKeyPlugins) > 0 {
 


### PR DESCRIPTION
We tend to create one localhost
service by default, in absence of
any server urls present in the spec.
This behaviour deviated in the last
merge: https://github.com/Kong/go-apiops/pull/270
Here, we are ensuring that at least
one service is created even if there are
no server urls, while ensuring that
no extra service is created in case server urls
are set at path or operation level.

FTI: https://konghq.atlassian.net/browse/FTI-6770
For #272 