### PR TITLE
Feat/openapi2mcp composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dist/
 # generated test files
 openapi2kong/oas3_testfiles/*.generated.json
 openapi2kong/oas3_testfiles/*.generated_inso.json
+openapi2mcp/oas3_testfiles/*.generated.json
 merge/merge_testfiles/*_generated.json
 
 # the binary

--- a/cmd/openapi2mcp.go
+++ b/cmd/openapi2mcp.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/kong/go-apiops/deckformat"
+	"github.com/kong/go-apiops/filebasics"
+	"github.com/kong/go-apiops/logbasics"
+	"github.com/kong/go-apiops/openapi2mcp"
+	"github.com/spf13/cobra"
+)
+
+// Executes the CLI command "openapi2mcp"
+func executeOpenapi2Mcp(cmd *cobra.Command, _ []string) error {
+	verbosity, _ := cmd.Flags().GetInt("verbose")
+	logbasics.Initialize(log.LstdFlags, verbosity)
+
+	inputFilename, err := cmd.Flags().GetString("spec")
+	if err != nil {
+		return fmt.Errorf("failed getting cli argument 'spec'; %w", err)
+	}
+
+	outputFilename, err := cmd.Flags().GetString("output-file")
+	if err != nil {
+		return fmt.Errorf("failed getting cli argument 'output-file'; %w", err)
+	}
+
+	docName, err := cmd.Flags().GetString("uuid-base")
+	if err != nil {
+		return fmt.Errorf("failed getting cli argument 'uuid-base'; %w", err)
+	}
+
+	var entityTags []string
+	{
+		tags, err := cmd.Flags().GetStringSlice("select-tag")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'select-tag'; %w", err)
+		}
+		entityTags = tags
+		if len(entityTags) == 0 {
+			entityTags = nil
+		}
+	}
+
+	var outputFormat string
+	{
+		outputFormat, err = cmd.Flags().GetString("format")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'format'; %w", err)
+		}
+		outputFormat = strings.ToUpper(outputFormat)
+	}
+
+	var mode string
+	{
+		mode, err = cmd.Flags().GetString("mode")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'mode'; %w", err)
+		}
+		// Validate mode
+		if mode != "" && mode != openapi2mcp.ModeConversion && mode != openapi2mcp.ModeConversionListener {
+			return fmt.Errorf("invalid mode '%s': must be '%s' or '%s'",
+				mode, openapi2mcp.ModeConversion, openapi2mcp.ModeConversionListener)
+		}
+	}
+
+	var pathPrefix string
+	{
+		pathPrefix, err = cmd.Flags().GetString("path-prefix")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'path-prefix'; %w", err)
+		}
+	}
+
+	var includeDirectRoute bool
+	{
+		includeDirectRoute, err = cmd.Flags().GetBool("include-direct-route")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'include-direct-route'; %w", err)
+		}
+	}
+
+	var noID bool
+	{
+		noID, err = cmd.Flags().GetBool("no-id")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'no-id'; %w", err)
+		}
+	}
+
+	var ignoreSecurityErrors bool
+	{
+		ignoreSecurityErrors, err = cmd.Flags().GetBool("ignore-security-errors")
+		if err != nil {
+			return fmt.Errorf("failed getting cli argument 'ignore-security-errors'; %w", err)
+		}
+	}
+
+	options := openapi2mcp.O2MOptions{
+		Tags:                 entityTags,
+		DocName:              docName,
+		Mode:                 mode,
+		PathPrefix:           pathPrefix,
+		IncludeDirectRoute:   includeDirectRoute,
+		SkipID:               noID,
+		IgnoreSecurityErrors: ignoreSecurityErrors,
+	}
+
+	trackInfo := deckformat.HistoryNewEntry("openapi2mcp")
+	trackInfo["input"] = inputFilename
+	trackInfo["output"] = outputFilename
+	trackInfo["uuid-base"] = docName
+	trackInfo["mode"] = mode
+
+	// do the work: read/convert/write
+	content, err := filebasics.ReadFile(inputFilename)
+	if err != nil {
+		return err
+	}
+	result, err := openapi2mcp.Convert(content, options)
+	if err != nil {
+		return fmt.Errorf("failed converting OpenAPI spec '%s'; %w", inputFilename, err)
+	}
+	deckformat.HistoryAppend(result, trackInfo)
+	return filebasics.WriteSerializedFile(outputFilename, result, filebasics.OutputFormat(outputFormat))
+}
+
+//
+//
+// Define the CLI data for the openapi2mcp command
+//
+//
+
+var openapi2mcpCmd = &cobra.Command{
+	Use:   "openapi2mcp",
+	Short: "Convert OpenAPI files to Kong's decK format with MCP (Model Context Protocol) configuration",
+	Long: `Convert OpenAPI files to Kong's decK format with ai-mcp-proxy plugin configuration.
+
+This command generates a Kong service with an MCP route that includes the ai-mcp-proxy
+plugin configured with tools derived from the OpenAPI specification operations.
+
+Each OpenAPI operation is mapped to an MCP tool definition:
+  - operationId -> tool name (kebab-case normalized)
+  - summary/description -> tool description
+  - parameters -> tool parameters array
+  - requestBody -> tool request_body
+
+Security/ACL generation:
+  When an oauth2 security scheme includes the x-kong-mcp-acl extension, ACL entries
+  are automatically generated for each tool based on the operation's security scopes.
+  The plugin config will include acl_attribute_type, access_token_claim_field, and
+  per-tool acl.allow arrays. Use x-kong-mcp-default-acl at the document level to
+  set a default ACL for the plugin. Use --ignore-security-errors to skip unsupported
+  security configurations instead of failing.
+
+Supported x-kong extensions:
+  - x-kong-name: Custom entity naming
+  - x-kong-tags: Tags for all entities
+  - x-kong-service-defaults: Service entity defaults
+  - x-kong-route-defaults: Route entity defaults
+  - x-kong-upstream-defaults: Upstream entity defaults
+  - x-kong-plugin-*: Additional plugins
+
+MCP-specific extensions:
+  - x-kong-mcp-tool-name: Override generated tool name
+  - x-kong-mcp-tool-description: Override tool description
+  - x-kong-mcp-exclude: Exclude operation from tool generation (boolean)
+  - x-kong-mcp-proxy: Override ai-mcp-proxy plugin config at document level
+
+Security extensions:
+  - x-kong-mcp-acl: ACL config on oauth2 security scheme (acl_attribute_type, access_token_claim_field)
+  - x-kong-mcp-default-acl: Default ACL array at document level (scope, allow)`,
+	RunE: executeOpenapi2Mcp,
+	Args: cobra.NoArgs,
+}
+
+func init() {
+	rootCmd.AddCommand(openapi2mcpCmd)
+	openapi2mcpCmd.Flags().StringP("spec", "s", "-", "OpenAPI spec file to process. Use - to read from stdin")
+	openapi2mcpCmd.Flags().StringP("output-file", "o", "-", "output file to write. Use - to write to stdout")
+	openapi2mcpCmd.Flags().StringP("format", "", string(filebasics.OutputFormatYaml), "output format: "+
+		string(filebasics.OutputFormatJSON)+" or "+string(filebasics.OutputFormatYaml))
+	openapi2mcpCmd.Flags().StringP("uuid-base", "", "",
+		`the unique base-string for uuid-v5 generation of entity id's (if omitted
+will use the root-level "x-kong-name" directive, or fall back to 'info.title')`)
+	openapi2mcpCmd.Flags().StringSlice("select-tag", nil,
+		`select tags to apply to all entities (if omitted will use the "x-kong-tags"
+directive from the file)`)
+	openapi2mcpCmd.Flags().StringP("mode", "m", openapi2mcp.ModeConversionListener,
+		`ai-mcp-proxy mode: "conversion" (client mode) or "conversion-listener" (server mode)`)
+	openapi2mcpCmd.Flags().StringP("path-prefix", "p", "",
+		`custom path prefix for the MCP route (default: /{service-name}-mcp)`)
+	openapi2mcpCmd.Flags().BoolP("include-direct-route", "", false,
+		`also generate non-MCP routes for direct API access`)
+	openapi2mcpCmd.Flags().BoolP("no-id", "", false,
+		`do not generate UUIDs for entities`)
+	openapi2mcpCmd.Flags().BoolP("ignore-security-errors", "", false,
+		`ignore errors for unsupported security schemes or missing x-kong-mcp-acl extensions`)
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,26 @@ The general pattern for this command is to provide an OAS file and output to a d
 deck file openapi2kong --spec <input-oas-file> --output-file <output-deck-file>
 ```
 ---
+### `openapi2mcp`
+
+The `openapi2mcp` transformation converts an OpenAPI Specification (OAS) to a Kong declarative
+configuration with the `ai-mcp-proxy` plugin for [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
+tool definitions. This allows you to expose your REST APIs as MCP tools for AI agents and LLM applications.
+
+For full documentation, see the [openapi2mcp docs](openapi2mcp/README.md).
+
+For full usage instructions, see the command help:
+
+```sh
+deck file openapi2mcp --help
+```
+
+Basic usage:
+
+```sh
+deck file openapi2mcp --spec <input-oas-file> --output-file <output-deck-file>
+```
+---
 ### `merge`
 
 The `merge` transformation will merge 2 or more Kong Declarative configurations into a single output.

--- a/docs/openapi2mcp/README.md
+++ b/docs/openapi2mcp/README.md
@@ -1,0 +1,477 @@
+# openapi2mcp
+
+The `openapi2mcp` command converts an OpenAPI 3.x specification into a Kong declarative configuration
+with the `ai-mcp-proxy` plugin for [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tool definitions.
+
+This allows you to expose your existing REST APIs as MCP tools that can be consumed by AI agents and LLM applications.
+
+## Usage
+
+```sh
+deck file openapi2mcp --help
+```
+
+Basic usage:
+
+```sh
+deck file openapi2mcp --spec <input-oas-file> --output-file <output-deck-file>
+```
+
+## Command Flags
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--spec`, `-s` | Path to the OpenAPI specification file (required) | - |
+| `--output-file`, `-o` | Output file path. Use `-` for stdout | `-` |
+| `--format` | Output format: `yaml` or `json` | `yaml` |
+| `--select-tag` | Tags to select from the spec (can be repeated) | - |
+| `--uuid-base` | Base UUID namespace for deterministic ID generation | - |
+| `--no-id` | Skip generating UUIDs for entities | `false` |
+| `--mode` | MCP proxy mode: `conversion-listener` or `conversion` | `conversion-listener` |
+| `--path-prefix` | Custom path prefix for the MCP route | `/<service-name>-mcp` |
+| `--include-direct-route` | Include direct routes to original API paths | `false` |
+| `--ignore-security-errors` | Ignore errors for unsupported security schemes when ACL generation is active | `false` |
+
+## How It Works
+
+The `openapi2mcp` command:
+
+1. Parses the OpenAPI specification
+2. Creates a Kong Service pointing to the upstream API server(s)
+3. Creates an MCP route with the `ai-mcp-proxy` plugin
+4. Converts each OpenAPI operation into an MCP tool definition
+
+### MCP Tool Generation
+
+Each OpenAPI operation is converted to an MCP tool with:
+
+- **name**: Derived from `x-kong-mcp-tool-name` extension, or `operationId` converted to kebab-case
+- **description**: Derived from `x-kong-mcp-tool-description` extension, operation `description`, or `summary` (in that priority order)
+- **method**: The HTTP method (GET, POST, PUT, DELETE, etc.)
+- **path**: The operation path with parameter placeholders
+- **parameters**: Query, path, and header parameters with simplified schemas
+- **request_body**: Request body schema (for POST, PUT, PATCH operations)
+- **annotations.title**: The operation `summary`
+
+### Schema Simplification
+
+Schemas are simplified to include only essential properties for MCP tool definitions:
+- `type`
+- `properties`
+- `required`
+- `items` (for arrays)
+
+Other schema properties like `format`, `pattern`, `minLength`, `maxLength`, etc. are filtered out.
+
+## MCP-Specific Extensions
+
+### `x-kong-mcp-exclude`
+
+Exclude an operation from MCP tool generation.
+
+```yaml
+paths:
+  /internal/health:
+    get:
+      x-kong-mcp-exclude: true
+      operationId: health-check
+      summary: Health check endpoint
+```
+
+### `x-kong-mcp-tool-name`
+
+Override the generated tool name.
+
+```yaml
+paths:
+  /flights:
+    get:
+      x-kong-mcp-tool-name: list-all-flights
+      operationId: getFlights
+      summary: Get flights
+```
+
+### `x-kong-mcp-tool-description`
+
+Override the tool description (takes priority over `description` and `summary` fields).
+
+```yaml
+paths:
+  /flights:
+    get:
+      x-kong-mcp-tool-description: Retrieve all scheduled flights for a specific date range
+      operationId: getFlights
+      summary: Get flights
+      description: Returns a list of flights
+```
+
+## Security & ACL Generation
+
+When your OpenAPI spec uses `oauth2` security schemes with the `x-kong-mcp-acl` extension,
+the converter automatically generates per-tool ACL entries and plugin-level ACL configuration
+in the `ai-mcp-proxy` plugin config.
+
+### How It Works
+
+1. **Auto-detection**: ACL generation activates when any `oauth2` security scheme in
+   `components/securitySchemes` has the `x-kong-mcp-acl` extension. No opt-in flag is needed.
+2. **Per-tool ACL**: Each operation's `security` scopes are converted to an `acl.allow` list
+   on the corresponding MCP tool.
+3. **Plugin-level config**: The `acl_attribute_type` and `access_token_claim_field` values
+   from `x-kong-mcp-acl` are added to the plugin config. An optional `default_acl` is read
+   from the document-level `x-kong-mcp-default-acl` extension.
+4. **Security inheritance**: Operations without an explicit `security` field inherit from the
+   document-level `security` array (standard OpenAPI semantics).
+5. **Opting out**: An operation with `security: []` (empty array) explicitly opts out —
+   no ACL entry is generated for that tool.
+
+### Supported Schemes
+
+Only `oauth2` security schemes are supported for ACL generation. Other scheme types
+(`apiKey`, `http`, `openIdConnect`) are ignored when no `x-kong-mcp-acl` extension is present.
+
+When ACL generation is active (at least one scheme has `x-kong-mcp-acl`) and an operation
+references a non-`oauth2` scheme or a scheme missing the extension, an error is returned.
+Use `--ignore-security-errors` to skip these operations instead of failing.
+
+Multiple security requirements (OR logic) and compound requirements (AND logic with
+multiple schemes in one requirement) also produce errors unless `--ignore-security-errors`
+is set.
+
+### Extensions
+
+#### `x-kong-mcp-acl` (on a security scheme)
+
+Placed on an `oauth2` security scheme in `components/securitySchemes`. Activates ACL
+generation and provides plugin-level configuration.
+
+| Field | Description |
+|-------|-------------|
+| `acl_attribute_type` | The type of attribute used for ACL (e.g., `oauth_access_token`) |
+| `access_token_claim_field` | The JWT/token claim field that contains the scopes (e.g., `scp`) |
+
+```yaml
+components:
+  securitySchemes:
+    my_oauth:
+      type: oauth2
+      x-kong-mcp-acl:
+        acl_attribute_type: oauth_access_token
+        access_token_claim_field: scp
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            read: Read access
+            write: Write access
+```
+
+#### `x-kong-mcp-default-acl` (document-level)
+
+Placed at the root level of the OpenAPI document. Defines a default ACL that applies
+at the plugin level (not per-tool).
+
+```yaml
+x-kong-mcp-default-acl:
+  - scope: tools
+    allow:
+      - "read"
+```
+
+### Example
+
+**Input:**
+```yaml
+openapi: 3.0.0
+info:
+  title: My API
+  version: 1.0.0
+
+x-kong-mcp-default-acl:
+  - scope: tools
+    allow:
+      - "data:read"
+
+servers:
+  - url: https://api.example.com
+
+security:
+  - my_oauth:
+      - data:read
+
+paths:
+  /items:
+    get:
+      operationId: listItems
+      summary: List items
+      security:
+        - my_oauth:
+            - data:read
+    post:
+      operationId: createItem
+      summary: Create item
+      security:
+        - my_oauth:
+            - data:write
+  /public:
+    get:
+      operationId: getPublicInfo
+      summary: Public info
+      security: []  # Opts out of security - no ACL generated
+
+components:
+  securitySchemes:
+    my_oauth:
+      type: oauth2
+      x-kong-mcp-acl:
+        acl_attribute_type: oauth_access_token
+        access_token_claim_field: scp
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.example.com/token
+          scopes:
+            data:read: Read data
+            data:write: Write data
+```
+
+**Output (relevant plugin config section):**
+```yaml
+plugins:
+- name: ai-mcp-proxy
+  config:
+    mode: conversion-listener
+    acl_attribute_type: oauth_access_token
+    access_token_claim_field: scp
+    default_acl:
+    - scope: tools
+      allow:
+      - "data:read"
+    tools:
+    - name: list-items
+      description: List items
+      method: GET
+      path: /items
+      acl:
+        allow:
+        - "data:read"
+    - name: create-item
+      description: Create item
+      method: POST
+      path: /items
+      acl:
+        allow:
+        - "data:write"
+    - name: get-public-info
+      description: Public info
+      method: GET
+      path: /public
+      # No acl — security: [] opted out
+```
+
+## Kong Extensions Support
+
+The `openapi2mcp` command also supports standard Kong extensions:
+
+| Extension | Level | Description |
+|-----------|-------|-------------|
+| `x-kong-name` | Document | Override the service name |
+| `x-kong-tags` | Document | Tags to apply to all generated entities |
+| `x-kong-service-defaults` | Document, Path, Operation | Default values for Kong Service entities |
+| `x-kong-route-defaults` | Document, Path, Operation | Default values for Kong Route entities |
+| `x-kong-upstream-defaults` | Document | Default values for Kong Upstream entities |
+| `x-kong-plugin-<name>` | Document, Path, Operation | Add Kong plugins to generated entities |
+
+## Examples
+
+### Basic Conversion
+
+**Input: flights-api.yaml**
+```yaml
+openapi: 3.0.0
+info:
+  title: Flights Service
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /flights:
+    get:
+      operationId: getFlights
+      summary: Get all flights
+      description: Retrieves a list of all available flights with optional filtering
+      parameters:
+        - name: date
+          in: query
+          description: Filter by departure date
+          required: false
+          schema:
+            type: string
+            format: date
+  /flights/{flightId}:
+    get:
+      operationId: getFlightById
+      summary: Get flight details
+      parameters:
+        - name: flightId
+          in: path
+          required: true
+          schema:
+            type: string
+```
+
+**Command:**
+```sh
+deck file openapi2mcp -s flights-api.yaml -o kong.yaml --no-id
+```
+
+**Output: kong.yaml**
+```yaml
+_format_version: "3.0"
+services:
+- host: api.example.com
+  name: flights-service
+  path: /v1
+  port: 443
+  protocol: https
+  plugins: []
+  routes:
+  - name: flights-service-mcp
+    paths:
+    - /flights-service-mcp
+    plugins:
+    - name: ai-mcp-proxy
+      config:
+        mode: conversion-listener
+        tools:
+        - name: get-flights
+          description: Retrieves a list of all available flights with optional filtering
+          method: GET
+          path: /flights
+          annotations:
+            title: Get all flights
+          parameters:
+          - name: date
+            in: query
+            required: false
+            description: Filter by departure date
+            schema:
+              type: string
+        - name: get-flight-by-id
+          description: Get flight details
+          method: GET
+          path: /flights/{flightId}
+          annotations:
+            title: Get flight details
+          parameters:
+          - name: flightId
+            in: path
+            required: true
+            schema:
+              type: string
+```
+
+### With MCP Extensions
+
+```yaml
+openapi: 3.0.0
+info:
+  title: Booking API
+servers:
+  - url: https://api.example.com
+paths:
+  /internal/metrics:
+    get:
+      x-kong-mcp-exclude: true  # Exclude from MCP tools
+      operationId: getMetrics
+      summary: Internal metrics endpoint
+  /bookings:
+    post:
+      x-kong-mcp-tool-name: create-new-booking
+      x-kong-mcp-tool-description: Create a new booking reservation for a customer
+      operationId: createBooking
+      summary: Create booking
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                customer_id:
+                  type: string
+                flight_id:
+                  type: string
+              required:
+                - customer_id
+                - flight_id
+```
+
+### Custom Path Prefix
+
+```sh
+deck file openapi2mcp -s api.yaml --path-prefix /ai/tools/flights
+```
+
+This generates an MCP route at `/ai/tools/flights` instead of the default `/<service-name>-mcp`.
+
+### Include Direct Routes
+
+```sh
+deck file openapi2mcp -s api.yaml --include-direct-route
+```
+
+This generates both:
+1. The MCP route with the `ai-mcp-proxy` plugin
+2. Direct routes to the original API endpoints (without the MCP plugin)
+
+### Conversion Mode
+
+```sh
+deck file openapi2mcp -s api.yaml --mode conversion
+```
+
+The `--mode` flag controls the `ai-mcp-proxy` plugin mode:
+- `conversion-listener` (default): The plugin listens for MCP tool calls and converts them to HTTP requests
+- `conversion`: The plugin only performs conversion without the listener functionality
+
+### Multiple Servers (Upstream with Load Balancing)
+
+When your OpenAPI spec has multiple servers, an Upstream entity is created with multiple targets:
+
+```yaml
+openapi: 3.0.0
+info:
+  title: Flights Service
+servers:
+  - url: https://api1.example.com/v1
+  - url: https://api2.example.com/v1
+  - url: https://api3.example.com/v1
+paths:
+  /flights:
+    get:
+      operationId: getFlights
+      summary: Get flights
+```
+
+This generates:
+- A Kong Upstream with 3 targets for load balancing
+- A Kong Service pointing to the Upstream
+- MCP route with tools
+
+## Tool Name Normalization
+
+Tool names are automatically converted to kebab-case:
+
+| operationId | Generated Tool Name |
+|-------------|---------------------|
+| `getFlights` | `get-flights` |
+| `GetFlights` | `get-flights` |
+| `get_flights` | `get-flights` |
+| `listAllUsers` | `list-all-users` |
+| `CreateNewItem` | `create-new-item` |
+
+## See Also
+
+- [openapi2kong](../README.md#openapi2kong) - Convert OpenAPI to Kong configuration (without MCP)
+- [Kong AI MCP Proxy Plugin](https://docs.konghq.com/hub/kong-inc/ai-mcp-proxy/) - Plugin documentation
+- [Model Context Protocol](https://modelcontextprotocol.io/) - MCP specification

--- a/docs/openapi2mcp/example_oas.yaml
+++ b/docs/openapi2mcp/example_oas.yaml
@@ -1,0 +1,360 @@
+---
+# This is an annotated OpenAPI spec demonstrating the openapi2mcp conversion features.
+# It shows how to use MCP-specific extensions and Kong extensions to customize
+# the generated MCP tool definitions.
+
+openapi: 3.0.0
+
+info:
+  description: KongAir Flight Booking Service
+  version: 1.0.0
+  title: KongAir Flights API
+
+servers:
+- url: https://api.kongair.example.com/v1
+  description: Production server
+- url: https://api-staging.kongair.example.com/v1
+  description: Staging server
+  # When multiple servers are specified, an Upstream entity is created
+  # with multiple targets for load balancing.
+
+x-kong-name: kongair-flights
+  # Override the service name. If not specified, the service name is derived
+  # from info.title converted to kebab-case (e.g., "kongair-flights-api").
+
+x-kong-tags: [mcp, flights, kongair]
+  # Tags to apply to all generated Kong entities (Service, Route, Plugin).
+  # These can be overridden via the --select-tag CLI flag.
+
+x-kong-mcp-default-acl:
+  # Default ACL applied at the plugin level (not per-tool).
+  # This is used when the ai-mcp-proxy plugin needs a fallback ACL policy.
+  - scope: tools
+    allow:
+      - "flights:read"
+
+# Document-level security: operations without explicit 'security' inherit this.
+security:
+  - kongair_oauth:
+      - flights:read
+
+x-kong-service-defaults:
+  # Default values for the generated Kong Service entity.
+  # See https://docs.konghq.com/gateway/latest/admin-api/#service-object
+  retries: 5
+  connect_timeout: 30000
+  write_timeout: 30000
+  read_timeout: 30000
+
+x-kong-route-defaults:
+  # Default values for the generated Kong Route entity.
+  # See https://docs.konghq.com/gateway/latest/admin-api/#route-object
+  preserve_host: true
+
+x-kong-upstream-defaults:
+  # Default values for the generated Kong Upstream entity (when multiple servers exist).
+  # See https://docs.konghq.com/gateway/latest/admin-api/#upstream-object
+  hash_on: ip
+  healthchecks:
+    passive:
+      unhealthy:
+        http_failures: 3
+
+paths:
+  /flights:
+    get:
+      operationId: getFlights
+      summary: List available flights
+      description: Retrieves a paginated list of available flights with optional filtering by date, origin, and destination airports.
+      # This operation inherits document-level security (kongair_oauth with flights:read scope).
+      # The tool will get an acl: { allow: ["flights:read"] } entry.
+      # The tool description uses "description" field first, falling back to "summary".
+      # In this case, the longer description will be used as the MCP tool description,
+      # while "summary" will be used for annotations.title.
+      parameters:
+        - name: date
+          in: query
+          description: Filter flights by departure date (ISO 8601 format)
+          required: false
+          schema:
+            type: string
+            format: date
+            # Note: "format" is stripped from the schema in MCP tool output
+            # Only essential properties (type, properties, required, items) are kept
+        - name: origin
+          in: query
+          description: Filter by origin airport code (e.g., SFO, LAX)
+          required: false
+          schema:
+            type: string
+            minLength: 3
+            maxLength: 3
+            # Note: minLength/maxLength are stripped from MCP output
+        - name: destination
+          in: query
+          description: Filter by destination airport code
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Flight'
+
+  /flights/{flightNumber}:
+    parameters:
+      # Path-level parameters are inherited by all operations under this path
+      - name: flightNumber
+        in: path
+        description: The unique flight number (e.g., KA123)
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getFlightDetails
+      summary: Get flight details
+      description: Retrieve detailed information about a specific flight including real-time status, gate information, and crew details.
+      responses:
+        '200':
+          description: Flight details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlightDetails'
+
+  /flights/{flightNumber}/bookings:
+    parameters:
+      - name: flightNumber
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      security:
+        - kongair_oauth:
+            - flights:write
+        # Explicit security with write scope. The tool will get acl: { allow: ["flights:write"] }.
+      x-kong-mcp-tool-name: book-flight
+        # Override the generated tool name. Without this extension,
+        # the tool name would be derived from operationId: "create-flight-booking"
+      x-kong-mcp-tool-description: Book a seat on a KongAir flight for a passenger. Requires passenger details and optional seat preferences.
+        # Override the tool description. This takes highest priority over
+        # both "description" and "summary" fields.
+      operationId: createFlightBooking
+      summary: Book a flight
+      description: Creates a new booking for the specified flight.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                passenger_name:
+                  type: string
+                  description: Full name of the passenger as it appears on ID
+                passenger_email:
+                  type: string
+                  format: email
+                seat_preference:
+                  type: string
+                  enum: [window, aisle, middle]
+                  description: Preferred seat location
+              required:
+                - passenger_name
+                - passenger_email
+      responses:
+        '201':
+          description: Booking created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Booking'
+
+  /internal/health:
+    get:
+      x-kong-mcp-exclude: true
+        # Exclude this operation from MCP tool generation.
+        # Health check endpoints typically shouldn't be exposed as AI tools.
+      security: []
+        # security: [] explicitly opts out of security for this operation.
+        # Even if this were not excluded, no ACL would be generated.
+      operationId: healthCheck
+      summary: Health check endpoint
+      responses:
+        '200':
+          description: Service is healthy
+
+  /internal/metrics:
+    get:
+      x-kong-mcp-exclude: true
+        # Another internal endpoint excluded from MCP tools
+      operationId: getMetrics
+      summary: Prometheus metrics endpoint
+      responses:
+        '200':
+          description: Metrics in Prometheus format
+
+  /bookings/{bookingId}:
+    parameters:
+      - name: bookingId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      operationId: getBooking
+      summary: Get booking details
+      # Only "summary" is provided here, so it will be used as the tool description
+      responses:
+        '200':
+          description: Booking details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Booking'
+    delete:
+      operationId: cancelBooking
+      summary: Cancel a booking
+      description: Cancel an existing booking. Cancellation policies and refund rules apply based on the time until departure.
+      responses:
+        '204':
+          description: Booking cancelled
+
+  /bookings/{bookingId}/check-in:
+    parameters:
+      - name: bookingId
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: checkIn
+      summary: Check in for flight
+      description: Complete online check-in for a booking. Returns boarding pass information.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                seat_selection:
+                  type: string
+                  description: Specific seat number if available (e.g., 12A)
+      responses:
+        '200':
+          description: Check-in successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BoardingPass'
+
+components:
+  securitySchemes:
+    kongair_oauth:
+      type: oauth2
+      x-kong-mcp-acl:
+        # This extension activates ACL generation for MCP tools.
+        # Only supported on oauth2 security schemes.
+        acl_attribute_type: oauth_access_token
+          # The type of attribute used for ACL (e.g., oauth_access_token).
+        access_token_claim_field: scp
+          # The JWT/token claim field that contains the scopes.
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.kongair.example.com/authorize
+          tokenUrl: https://auth.kongair.example.com/token
+          scopes:
+            flights:read: Read access to flight resources
+            flights:write: Write access to flight resources
+
+  schemas:
+    Flight:
+      type: object
+      properties:
+        flight_number:
+          type: string
+        origin:
+          type: string
+        destination:
+          type: string
+        departure_time:
+          type: string
+          format: date-time
+        arrival_time:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [scheduled, boarding, departed, arrived, cancelled]
+        available_seats:
+          type: integer
+
+    FlightDetails:
+      allOf:
+        - $ref: '#/components/schemas/Flight'
+        - type: object
+          properties:
+            gate:
+              type: string
+            terminal:
+              type: string
+            aircraft_type:
+              type: string
+
+    Booking:
+      type: object
+      properties:
+        booking_id:
+          type: string
+          format: uuid
+        flight_number:
+          type: string
+        passenger_name:
+          type: string
+        passenger_email:
+          type: string
+        seat_number:
+          type: string
+        status:
+          type: string
+          enum: [confirmed, checked_in, cancelled]
+        created_at:
+          type: string
+          format: date-time
+
+    BoardingPass:
+      type: object
+      properties:
+        booking_id:
+          type: string
+        flight_number:
+          type: string
+        passenger_name:
+          type: string
+        seat_number:
+          type: string
+        gate:
+          type: string
+        boarding_time:
+          type: string
+          format: date-time
+        barcode:
+          type: string
+          description: QR code data for scanning

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/go-apiops/filebasics"
 	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-apiops/logbasics"
+	"github.com/kong/go-apiops/openapitools"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
 	openapibase "github.com/pb33f/libopenapi/datamodel/high/base"
@@ -137,7 +138,7 @@ func getXKongObject(
 		return nil, nil
 	}
 
-	xKongObjectBytes, err := convertYamlNodeToBytes(xKongObject)
+	xKongObjectBytes, err := openapitools.ConvertYamlNodeToBytes(xKongObject)
 	if err != nil {
 		return nil, fmt.Errorf("expected '%s' to be a YAML object", key)
 	}
@@ -149,7 +150,7 @@ func getXKongObject(
 		return nil, fmt.Errorf("expected '%s' to be a JSON/YAML object", key)
 	}
 
-	object, err := dereferenceJSONObject(jsonObject, components)
+	object, err := openapitools.DereferenceJSONObject(jsonObject, components)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func getXKongComponents(doc v3.Document) (*map[string]interface{}, error) {
 		return &components, nil
 	}
 
-	xKongComponentsBytes, err := convertYamlNodeToBytes(xKongComponents)
+	xKongComponentsBytes, err := openapitools.ConvertYamlNodeToBytes(xKongComponents)
 	if err != nil {
 		return nil, fmt.Errorf("expected '/components/x-kong' to be a YAML object")
 	}
@@ -602,7 +603,7 @@ func constructHeaderCombinationsForRouting(headers []*v3.Parameter) []map[string
 			headerValues[i] = append(headerValues[i], enumMember.Value)
 		}
 	}
-	headerValueCombinations := crossProduct(headerValues...)
+	headerValueCombinations := openapitools.CrossProduct(headerValues...)
 
 	var result []map[string]any
 	for _, combination := range headerValueCombinations {
@@ -749,7 +750,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 			}
 		}
 	}
-	docBaseName = Slugify(opts.InsoCompat, docBaseName)
+	docBaseName = openapitools.Slugify(opts.InsoCompat, docBaseName)
 	logbasics.Info("document name (namespace for UUID generation)", "name", docBaseName)
 
 	if kongComponents, err = getXKongComponents(doc); err != nil {
@@ -768,7 +769,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	}
 
 	// create the top-level docService and (optional) docUpstream
-	docService, docUpstream, err = CreateKongService(docBaseName, docServers, docServiceDefaults,
+	docService, docUpstream, err = openapitools.CreateKongService(docBaseName, docServers, docServiceDefaults,
 		docUpstreamDefaults, kongTags, opts.UUIDNamespace, opts.SkipID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create service/upstream from document root: %w", err)
@@ -863,7 +864,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 		if pathBaseName == "" {
 			// no given name, so use the path itself to construct the name
 			if !opts.InsoCompat {
-				pathBaseName = Slugify(opts.InsoCompat, pathKey)
+				pathBaseName = openapitools.Slugify(opts.InsoCompat, pathKey)
 				if strings.HasSuffix(pathKey, "/") {
 					// a common case is 2 paths, one with and one without a trailing "/" so to prevent
 					// duplicate names being generated, we add a "~" suffix as a special case to cater
@@ -872,10 +873,10 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 				}
 			} else {
 				// we need inso compatibility
-				pathBaseName = Slugify(opts.InsoCompat, pathKey)
+				pathBaseName = openapitools.Slugify(opts.InsoCompat, pathKey)
 			}
 		} else {
-			pathBaseName = Slugify(opts.InsoCompat, pathBaseName)
+			pathBaseName = openapitools.Slugify(opts.InsoCompat, pathBaseName)
 		}
 		if pathBaseName != "" {
 			pathBaseName = docBaseName + nameConcatChar + pathBaseName
@@ -926,7 +927,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 		if newPathService {
 			// create the path-level service and (optional) upstream
 			logbasics.Debug("creating path-level service/upstream")
-			pathService, pathUpstream, err = CreateKongService(
+			pathService, pathUpstream, err = openapitools.CreateKongService(
 				pathBaseName,
 				pathServers,
 				pathServiceDefaults,
@@ -1019,23 +1020,23 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 			if operationBaseName != "" {
 				if opts.InsoCompat {
 					// an x-kong-name was provided, so build as "doc-name"
-					operationBaseName = docBaseName + nameConcatChar + Slugify(opts.InsoCompat, operationBaseName)
+					operationBaseName = docBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, operationBaseName)
 				} else {
 					// an x-kong-name was provided, so build as "doc-path-name"
-					operationBaseName = pathBaseName + nameConcatChar + Slugify(opts.InsoCompat, operationBaseName)
+					operationBaseName = pathBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, operationBaseName)
 				}
 			} else {
 				operationBaseName = operation.OperationId
 				if operationBaseName == "" {
 					// no operation ID provided, so build as "doc-path-method"
 					if opts.InsoCompat {
-						operationBaseName = pathBaseName + nameConcatChar + Slugify(opts.InsoCompat, strings.ToLower(methodKey))
+						operationBaseName = pathBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, strings.ToLower(methodKey))
 					} else {
-						operationBaseName = pathBaseName + nameConcatChar + Slugify(opts.InsoCompat, methodKey)
+						operationBaseName = pathBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, methodKey)
 					}
 				} else {
 					// operation ID is provided, so build as "doc-operationid"
-					operationBaseName = docBaseName + nameConcatChar + Slugify(opts.InsoCompat, operationBaseName)
+					operationBaseName = docBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, operationBaseName)
 				}
 			}
 			logbasics.Debug("operation base name (namespace for UUID generation)", "name", operationBaseName)
@@ -1082,7 +1083,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 			if newOperationService {
 				// create the operation-level service and (optional) upstream
 				logbasics.Debug("creating operation-level service/upstream")
-				operationService, operationUpstream, err = CreateKongService(
+				operationService, operationUpstream, err = openapitools.CreateKongService(
 					operationBaseName,
 					operationServers,
 					operationServiceDefaults,
@@ -1190,7 +1191,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 					varName := match[1]
 					// match single segment; '/', '?', and '#' can mark the end of a segment
 					// see https://github.com/OAI/OpenAPI-Specification/issues/291#issuecomment-316593913
-					captureName := sanitizeRegexCapture(varName, opts.InsoCompat)
+					captureName := openapitools.SanitizeRegexCapture(varName, opts.InsoCompat)
 					if len(captureName) >= 32 {
 						return nil, fmt.Errorf("path-parameter name exceeds 32 characters: '%s' (sanitized to '%s')",
 							varName, captureName)

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -586,7 +586,9 @@ func findHeaderParamsForRouting(
 
 func shouldAddHeaderParameter(param *v3.Parameter, treatAllHeadersAsRequired bool) bool {
 	hasEnum := param.Schema != nil && param.Schema.Schema() != nil && len(param.Schema.Schema().Enum) > 0
-	isRequired := *param.Required || treatAllHeadersAsRequired
+
+	isParamRequired := param.Required != nil && *param.Required
+	isRequired := isParamRequired || treatAllHeadersAsRequired
 	return param.In == "header" && hasEnum && isRequired
 }
 

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -122,78 +122,12 @@ func getKongName(extensions *orderedmap.Map[string, *yaml.Node]) (string, error)
 	return name, nil
 }
 
-// getXKongObject returns specified 'key' from the extension properties if available.
-// returns nil if it wasn't found, an error if it wasn't an object or couldn't be
-// dereferenced. The returned object will be json encoded again.
-func getXKongObject(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	key string, components *map[string]interface{},
-) ([]byte, error) {
-	if extensions == nil {
-		return nil, nil
-	}
-
-	xKongObject, ok := extensions.Get(key)
-	if !ok || xKongObject == nil {
-		return nil, nil
-	}
-
-	xKongObjectBytes, err := openapitools.ConvertYamlNodeToBytes(xKongObject)
-	if err != nil {
-		return nil, fmt.Errorf("expected '%s' to be a YAML object", key)
-	}
-
-	var jsonBlob interface{}
-	_ = yaml.Unmarshal(xKongObjectBytes, &jsonBlob)
-	jsonObject, err := jsonbasics.ToObject(jsonBlob)
-	if err != nil {
-		return nil, fmt.Errorf("expected '%s' to be a JSON/YAML object", key)
-	}
-
-	object, err := openapitools.DereferenceJSONObject(jsonObject, components)
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(object)
-}
-
-// getXKongComponents will return a map of the '/components/x-kong/' object. If
-// the extension is not there it will return an empty map. If the entry is not a
-// yaml object, it will return an error.
-func getXKongComponents(doc v3.Document) (*map[string]interface{}, error) {
-	var components map[string]interface{}
-
-	if doc.Components == nil || doc.Components.Extensions == nil {
-		return &map[string]interface{}{}, nil
-	}
-
-	xKongComponents, ok := doc.Components.Extensions.Get("x-kong")
-
-	if !ok || xKongComponents == nil {
-		return &components, nil
-	}
-
-	xKongComponentsBytes, err := openapitools.ConvertYamlNodeToBytes(xKongComponents)
-	if err != nil {
-		return nil, fmt.Errorf("expected '/components/x-kong' to be a YAML object")
-	}
-
-	var xKong interface{}
-	_ = yaml.Unmarshal(xKongComponentsBytes, &xKong)
-	components, err = jsonbasics.ToObject(xKong)
-	if err != nil {
-		return nil, fmt.Errorf("expected '/components/x-kong' to be a JSON/YAML object")
-	}
-
-	return &components, nil
-}
-
 // getServiceDefaults returns a JSON string containing the defaults
 func getServiceDefaults(
 	extensions *orderedmap.Map[string, *yaml.Node],
 	components *map[string]interface{},
 ) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-service-defaults", components)
+	return openapitools.GetXKongObject(extensions, "x-kong-service-defaults", components)
 }
 
 // getUpstreamDefaults returns a JSON string containing the defaults
@@ -201,15 +135,7 @@ func getUpstreamDefaults(
 	extensions *orderedmap.Map[string, *yaml.Node],
 	components *map[string]interface{},
 ) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-upstream-defaults", components)
-}
-
-// getRouteDefaults returns a JSON string containing the defaults
-func getRouteDefaults(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	components *map[string]interface{},
-) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-route-defaults", components)
+	return openapitools.GetXKongObject(extensions, "x-kong-upstream-defaults", components)
 }
 
 // getOIDCdefaults returns a JSON string containing the defaults from the SecurityRequirements. The type must
@@ -283,13 +209,13 @@ func getOIDCdefaults(
 		pluginConfig map[string]interface{} // the plugin.config object
 	)
 	{
-		kongComponents, err := getXKongComponents(doc)
+		kongComponents, err := openapitools.GetXKongComponents(doc)
 		if err != nil {
 			return nil, err
 		}
 
 		// grab the base plugin config from the x-kong-... directive
-		pluginBaseData, err := getXKongObject(scheme.Extensions, "x-kong-security-openid-connect", kongComponents)
+		pluginBaseData, err := openapitools.GetXKongObject(scheme.Extensions, "x-kong-security-openid-connect", kongComponents)
 		if err != nil {
 			return nil, err
 		}
@@ -400,7 +326,7 @@ func getPluginsList(
 		if strings.HasPrefix(extensionName, "x-kong-plugin-") {
 			pluginName := strings.TrimPrefix(extensionName, "x-kong-plugin-")
 
-			jsonstr, err := getXKongObject(extensions, extensionName, components)
+			jsonstr, err := openapitools.GetXKongObject(extensions, extensionName, components)
 			if err != nil {
 				return nil, err
 			}
@@ -753,7 +679,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	docBaseName = openapitools.Slugify(opts.InsoCompat, docBaseName)
 	logbasics.Info("document name (namespace for UUID generation)", "name", docBaseName)
 
-	if kongComponents, err = getXKongComponents(doc); err != nil {
+	if kongComponents, err = openapitools.GetXKongComponents(doc); err != nil {
 		return nil, err
 	}
 
@@ -764,7 +690,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 	if docUpstreamDefaults, err = getUpstreamDefaults(doc.Extensions, kongComponents); err != nil {
 		return nil, err
 	}
-	if docRouteDefaults, err = getRouteDefaults(doc.Extensions, kongComponents); err != nil {
+	if docRouteDefaults, err = openapitools.GetRouteDefaults(doc.Extensions, kongComponents); err != nil {
 		return nil, err
 	}
 
@@ -907,7 +833,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 			newPathService = true
 		}
 
-		if pathRouteDefaults, err = getRouteDefaults(pathitem.Extensions, kongComponents); err != nil {
+		if pathRouteDefaults, err = openapitools.GetRouteDefaults(pathitem.Extensions, kongComponents); err != nil {
 			return nil, err
 		}
 		if pathRouteDefaults == nil {
@@ -1063,7 +989,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 				newOperationService = true
 			}
 
-			if operationRouteDefaults, err = getRouteDefaults(operation.Extensions, kongComponents); err != nil {
+			if operationRouteDefaults, err = openapitools.GetRouteDefaults(operation.Extensions, kongComponents); err != nil {
 				return nil, err
 			}
 			if operationRouteDefaults == nil {

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -215,7 +215,8 @@ func getOIDCdefaults(
 		}
 
 		// grab the base plugin config from the x-kong-... directive
-		pluginBaseData, err := openapitools.GetXKongObject(scheme.Extensions, "x-kong-security-openid-connect", kongComponents)
+		pluginBaseData, err := openapitools.GetXKongObject(
+			scheme.Extensions, "x-kong-security-openid-connect", kongComponents)
 		if err != nil {
 			return nil, err
 		}
@@ -956,9 +957,11 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 				if operationBaseName == "" {
 					// no operation ID provided, so build as "doc-path-method"
 					if opts.InsoCompat {
-						operationBaseName = pathBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, strings.ToLower(methodKey))
+						operationBaseName = pathBaseName +
+							nameConcatChar + openapitools.Slugify(opts.InsoCompat, strings.ToLower(methodKey))
 					} else {
-						operationBaseName = pathBaseName + nameConcatChar + openapitools.Slugify(opts.InsoCompat, methodKey)
+						operationBaseName = pathBaseName +
+							nameConcatChar + openapitools.Slugify(opts.InsoCompat, methodKey)
 					}
 				} else {
 					// operation ID is provided, so build as "doc-operationid"

--- a/openapi2kong/validator.go
+++ b/openapi2kong/validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-apiops/logbasics"
+	"github.com/kong/go-apiops/openapitools"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
@@ -96,7 +97,7 @@ func generateParameterSchema(operation *v3.Operation, path *v3.PathItem,
 			paramConf["in"] = parameter.In
 
 			if parameter.In == "path" {
-				paramConf["name"] = sanitizeRegexCapture(parameter.Name, insoCompat)
+				paramConf["name"] = openapitools.SanitizeRegexCapture(parameter.Name, insoCompat)
 			} else {
 				paramConf["name"] = parameter.Name
 			}

--- a/openapi2mcp/oas3_testfiles/01-basic-conversion.expected.json
+++ b/openapi2mcp/oas3_testfiles/01-basic-conversion.expected.json
@@ -1,0 +1,107 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "shared-services.kong-sales-engineering.com",
+      "id": "0cef4d36-9c39-5ac2-9d9f-190d8ea8a252",
+      "name": "flights-service",
+      "path": "/kongair",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "b9cc2f2b-2428-59bf-b355-2c4026dd0a08",
+          "name": "flights-service-mcp",
+          "paths": [
+            "/flights-service-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "Get KongAir planned flights"
+                    },
+                    "description": "Get KongAir planned flights",
+                    "method": "GET",
+                    "name": "get-flights",
+                    "parameters": [
+                      {
+                        "description": "Filter by date (defaults to current day)",
+                        "in": "query",
+                        "name": "date",
+                        "required": false,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "path": "/flights"
+                  },
+                  {
+                    "annotations": {
+                      "title": "Book a flight"
+                    },
+                    "description": "Book a flight",
+                    "method": "POST",
+                    "name": "book-flight",
+                    "parameters": [
+                      {
+                        "in": "path",
+                        "name": "flightNumber",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "path": "/flights/{flightNumber}/bookings",
+                    "request_body": {
+                      "content": {
+                        "application/json": {
+                          "schema": {
+                            "properties": {
+                              "passenger_email": {
+                                "type": "string"
+                              },
+                              "passenger_name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "passenger_name",
+                              "passenger_email"
+                            ],
+                            "type": "object"
+                          }
+                        }
+                      },
+                      "required": true
+                    }
+                  }
+                ]
+              },
+              "id": "15606d9f-b942-5adf-976f-bdbb9e24bd47",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_01-basic-conversion.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_01-basic-conversion.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_01-basic-conversion.yaml"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/01-basic-conversion.yaml
+++ b/openapi2mcp/oas3_testfiles/01-basic-conversion.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Flights Service
+servers:
+  - url: https://shared-services.kong-sales-engineering.com/kongair
+paths:
+  /flights:
+    get:
+      summary: Get KongAir planned flights
+      operationId: get-flights
+      parameters:
+        - name: date
+          in: query
+          description: Filter by date (defaults to current day)
+          required: false
+          schema:
+            type: string
+            format: date
+  /flights/{flightNumber}/bookings:
+    post:
+      summary: Book a flight
+      operationId: book-flight
+      parameters:
+        - name: flightNumber
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                passenger_name:
+                  type: string
+                passenger_email:
+                  type: string
+              required:
+                - passenger_name
+                - passenger_email

--- a/openapi2mcp/oas3_testfiles/02-mcp-extensions.expected.json
+++ b/openapi2mcp/oas3_testfiles/02-mcp-extensions.expected.json
@@ -1,0 +1,89 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "api.example.com",
+      "id": "0cef4d36-9c39-5ac2-9d9f-190d8ea8a252",
+      "name": "flights-service",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "b9cc2f2b-2428-59bf-b355-2c4026dd0a08",
+          "name": "flights-service-mcp",
+          "paths": [
+            "/flights-service-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "Create booking"
+                    },
+                    "description": "Creates a new flight booking with the specified passenger details and flight information",
+                    "method": "POST",
+                    "name": "create-booking",
+                    "path": "/bookings",
+                    "request_body": {
+                      "content": {
+                        "application/json": {
+                          "schema": {
+                            "properties": {
+                              "flight_id": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        }
+                      },
+                      "required": true
+                    }
+                  },
+                  {
+                    "annotations": {
+                      "title": "Get flights"
+                    },
+                    "description": "Retrieve all scheduled KongAir flights for a specific date",
+                    "method": "GET",
+                    "name": "list-flights",
+                    "parameters": [
+                      {
+                        "in": "query",
+                        "name": "date",
+                        "required": false,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "path": "/flights"
+                  }
+                ]
+              },
+              "id": "15606d9f-b942-5adf-976f-bdbb9e24bd47",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_02-mcp-extensions.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_02-mcp-extensions.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_02-mcp-extensions.yaml"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/02-mcp-extensions.yaml
+++ b/openapi2mcp/oas3_testfiles/02-mcp-extensions.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.0
+info:
+  title: Flights Service
+servers:
+  - url: https://api.example.com
+paths:
+  /internal/health:
+    get:
+      x-kong-mcp-exclude: true
+      operationId: health-check
+      summary: Health check endpoint
+  /flights:
+    get:
+      x-kong-mcp-tool-name: list-flights
+      x-kong-mcp-tool-description: Retrieve all scheduled KongAir flights for a specific date
+      operationId: get-flights
+      summary: Get flights
+      parameters:
+        - name: date
+          in: query
+          required: false
+          schema:
+            type: string
+  /bookings:
+    post:
+      operationId: create-booking
+      summary: Create booking
+      description: Creates a new flight booking with the specified passenger details and flight information
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                flight_id:
+                  type: string

--- a/openapi2mcp/oas3_testfiles/03-mode-conversion.expected.json
+++ b/openapi2mcp/oas3_testfiles/03-mode-conversion.expected.json
@@ -1,0 +1,55 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "api.example.com",
+      "id": "a49d53c1-c2ce-5d7c-a72c-e2c376de9e93",
+      "name": "simple-api",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "f7867c0b-488d-57c5-ae54-68b69916c422",
+          "name": "simple-api-mcp",
+          "paths": [
+            "/simple-api-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "List all users"
+                    },
+                    "description": "List all users",
+                    "method": "GET",
+                    "name": "list-users",
+                    "path": "/users"
+                  }
+                ]
+              },
+              "id": "079e4dfb-892f-5015-85f6-1e73358bbf76",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_03-mode-conversion.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_03-mode-conversion.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_03-mode-conversion.yaml"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/03-mode-conversion.yaml
+++ b/openapi2mcp/oas3_testfiles/03-mode-conversion.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: list-users
+      summary: List all users

--- a/openapi2mcp/oas3_testfiles/04-direct-route.expected.json
+++ b/openapi2mcp/oas3_testfiles/04-direct-route.expected.json
@@ -1,0 +1,108 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "api.example.com",
+      "id": "a49d53c1-c2ce-5d7c-a72c-e2c376de9e93",
+      "name": "simple-api",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "f7867c0b-488d-57c5-ae54-68b69916c422",
+          "name": "simple-api-mcp",
+          "paths": [
+            "/simple-api-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "List all users"
+                    },
+                    "description": "List all users",
+                    "method": "GET",
+                    "name": "list-users",
+                    "path": "/users"
+                  },
+                  {
+                    "annotations": {
+                      "title": "Get a user by ID"
+                    },
+                    "description": "Get a user by ID",
+                    "method": "GET",
+                    "name": "get-user",
+                    "parameters": [
+                      {
+                        "in": "path",
+                        "name": "userId",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "path": "/users/{userId}"
+                  }
+                ]
+              },
+              "id": "079e4dfb-892f-5015-85f6-1e73358bbf76",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_04-direct-route.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_04-direct-route.yaml"
+          ]
+        },
+        {
+          "id": "8ee40f6f-ac2c-5476-a3e3-7085d5e138a9",
+          "methods": [
+            "GET"
+          ],
+          "name": "simple-api_list-users",
+          "paths": [
+            "~/users$"
+          ],
+          "plugins": [],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_04-direct-route.yaml"
+          ]
+        },
+        {
+          "id": "592b00d2-940a-5b61-8d87-c0084e212371",
+          "methods": [
+            "GET"
+          ],
+          "name": "simple-api_get-user",
+          "paths": [
+            "~/users/(?\u003cuserid\u003e[^#?/]+)$"
+          ],
+          "plugins": [],
+          "regex_priority": 100,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_04-direct-route.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_04-direct-route.yaml"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/04-direct-route.yaml
+++ b/openapi2mcp/oas3_testfiles/04-direct-route.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      operationId: list-users
+      summary: List all users
+  /users/{userId}:
+    get:
+      operationId: get-user
+      summary: Get a user by ID
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string

--- a/openapi2mcp/oas3_testfiles/05-kong-extensions.expected.json
+++ b/openapi2mcp/oas3_testfiles/05-kong-extensions.expected.json
@@ -1,0 +1,71 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "connect_timeout": 30000,
+      "host": "api.example.com",
+      "id": "fdac7b37-a1ab-5285-8d5d-03df0060d00a",
+      "name": "api-with-kong-extensions",
+      "path": "/v1",
+      "plugins": [
+        {
+          "config": {
+            "minute": 100,
+            "policy": "local"
+          },
+          "id": "aa34328e-ed4e-5fe2-b13c-36511cf99ed5",
+          "name": "rate-limiting",
+          "tags": [
+            "production",
+            "v1"
+          ]
+        }
+      ],
+      "port": 443,
+      "protocol": "https",
+      "retries": 5,
+      "routes": [
+        {
+          "id": "5858ba16-9cbf-5b09-8eb6-436b3fc6b255",
+          "name": "api-with-kong-extensions-mcp",
+          "paths": [
+            "/api-with-kong-extensions-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "List all items"
+                    },
+                    "description": "List all items",
+                    "method": "GET",
+                    "name": "list-items",
+                    "path": "/items"
+                  }
+                ]
+              },
+              "id": "02813e53-ee50-560c-883a-ee1c4fe6b47c",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "production",
+                "v1"
+              ]
+            }
+          ],
+          "preserve_host": true,
+          "tags": [
+            "production",
+            "v1"
+          ]
+        }
+      ],
+      "tags": [
+        "production",
+        "v1"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/05-kong-extensions.yaml
+++ b/openapi2mcp/oas3_testfiles/05-kong-extensions.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: API with Kong Extensions
+x-kong-tags:
+  - production
+  - v1
+x-kong-service-defaults:
+  retries: 5
+  connect_timeout: 30000
+x-kong-route-defaults:
+  preserve_host: true
+x-kong-plugin-rate-limiting:
+  config:
+    minute: 100
+    policy: local
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List all items

--- a/openapi2mcp/oas3_testfiles/06-custom-path-prefix.expected.json
+++ b/openapi2mcp/oas3_testfiles/06-custom-path-prefix.expected.json
@@ -1,0 +1,55 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "api.example.com",
+      "id": "a49d53c1-c2ce-5d7c-a72c-e2c376de9e93",
+      "name": "simple-api",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "f7867c0b-488d-57c5-ae54-68b69916c422",
+          "name": "simple-api-mcp",
+          "paths": [
+            "/custom/mcp/path"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "List all items"
+                    },
+                    "description": "List all items",
+                    "method": "GET",
+                    "name": "list-items",
+                    "path": "/items"
+                  }
+                ]
+              },
+              "id": "079e4dfb-892f-5015-85f6-1e73358bbf76",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_06-custom-path-prefix.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_06-custom-path-prefix.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_06-custom-path-prefix.yaml"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/06-custom-path-prefix.yaml
+++ b/openapi2mcp/oas3_testfiles/06-custom-path-prefix.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.0
+info:
+  title: Simple API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List all items

--- a/openapi2mcp/oas3_testfiles/07-multiple-servers.expected.json
+++ b/openapi2mcp/oas3_testfiles/07-multiple-servers.expected.json
@@ -1,0 +1,81 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "multi-server-api.upstream",
+      "id": "75b3477b-1d8f-5f6b-b594-4d0e1d5a8ab4",
+      "name": "multi-server-api",
+      "path": "/api",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "29c780c2-9663-5632-813e-659f7df0f45c",
+          "name": "multi-server-api-mcp",
+          "paths": [
+            "/multi-server-api-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "annotations": {
+                      "title": "List all items"
+                    },
+                    "description": "List all items",
+                    "method": "GET",
+                    "name": "list-items",
+                    "path": "/items"
+                  }
+                ]
+              },
+              "id": "3ea297e1-9bb1-5b29-9b6a-69130c4ffdfe",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_07-multiple-servers.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_07-multiple-servers.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_07-multiple-servers.yaml"
+      ]
+    }
+  ],
+  "upstreams": [
+    {
+      "id": "fdaf4aad-438c-597b-a3e7-122e30cedbe5",
+      "name": "multi-server-api.upstream",
+      "tags": [
+        "OAS3_import",
+        "OAS3file_07-multiple-servers.yaml"
+      ],
+      "targets": [
+        {
+          "tags": [
+            "OAS3_import",
+            "OAS3file_07-multiple-servers.yaml"
+          ],
+          "target": "server1.example.com:443"
+        },
+        {
+          "tags": [
+            "OAS3_import",
+            "OAS3file_07-multiple-servers.yaml"
+          ],
+          "target": "server2.example.com:443"
+        }
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/07-multiple-servers.yaml
+++ b/openapi2mcp/oas3_testfiles/07-multiple-servers.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: Multi Server API
+servers:
+  - url: https://server1.example.com/api
+  - url: https://server2.example.com/api
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List all items

--- a/openapi2mcp/oas3_testfiles/08-security-acl.expected.json
+++ b/openapi2mcp/oas3_testfiles/08-security-acl.expected.json
@@ -1,0 +1,150 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "mock-e91bb6429fe84bfeb970620df9499e52.mock.insomnia.run",
+      "id": "259da73d-d48d-59b5-99fc-dbd49ce1a1d7",
+      "name": "kongair-flights",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "6916ad46-4c19-56d8-aaad-0c09dba4b135",
+          "name": "kongair-flights-mcp",
+          "paths": [
+            "/kongair-flights-mcp"
+          ],
+          "plugins": [
+            {
+              "config": {
+                "access_token_claim_field": "scp",
+                "acl_attribute_type": "oauth_access_token",
+                "default_acl": [
+                  {
+                    "allow": [
+                      "flights:read"
+                    ],
+                    "scope": "tools"
+                  }
+                ],
+                "mode": "conversion-listener",
+                "tools": [
+                  {
+                    "acl": {
+                      "allow": [
+                        "flights:read"
+                      ]
+                    },
+                    "annotations": {
+                      "title": "Get KongAir planned flights"
+                    },
+                    "description": "Returns all the scheduled flights for a given day\n",
+                    "method": "GET",
+                    "name": "get-cool-flights",
+                    "parameters": [
+                      {
+                        "description": "Filter by date (defaults to current day)",
+                        "in": "query",
+                        "name": "date",
+                        "required": false,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "path": "/flights"
+                  },
+                  {
+                    "acl": {
+                      "allow": [
+                        "flights:write"
+                      ]
+                    },
+                    "annotations": {
+                      "title": "Create a new flight"
+                    },
+                    "description": "Creates a new scheduled flight entry\n",
+                    "method": "POST",
+                    "name": "create-flight",
+                    "path": "/flights",
+                    "request_body": {
+                      "content": {
+                        "application/json": {
+                          "schema": {
+                            "properties": {
+                              "number": {
+                                "type": "string"
+                              },
+                              "route_id": {
+                                "type": "string"
+                              },
+                              "scheduled_arrival": {
+                                "type": "string"
+                              },
+                              "scheduled_departure": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "number",
+                              "route_id",
+                              "scheduled_departure",
+                              "scheduled_arrival"
+                            ],
+                            "type": "object"
+                          }
+                        }
+                      },
+                      "required": true
+                    }
+                  },
+                  {
+                    "acl": {
+                      "allow": [
+                        "flights:read"
+                      ]
+                    },
+                    "annotations": {
+                      "title": "Get a specific flight by flight number"
+                    },
+                    "description": "Returns a specific flight given its flight number\n",
+                    "method": "GET",
+                    "name": "get-flight-by-number",
+                    "parameters": [
+                      {
+                        "description": "The flight number",
+                        "in": "path",
+                        "name": "flightNumber",
+                        "required": true,
+                        "schema": {
+                          "type": "string"
+                        }
+                      }
+                    ],
+                    "path": "/flights/{flightNumber}"
+                  }
+                ]
+              },
+              "id": "7d56a807-dd7f-5660-8de3-d7611dd5ad28",
+              "name": "ai-mcp-proxy",
+              "tags": [
+                "OAS3_import",
+                "OAS3file_08-security-acl.yaml"
+              ]
+            }
+          ],
+          "tags": [
+            "OAS3_import",
+            "OAS3file_08-security-acl.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_08-security-acl.yaml"
+      ]
+    }
+  ]
+}

--- a/openapi2mcp/oas3_testfiles/08-security-acl.yaml
+++ b/openapi2mcp/oas3_testfiles/08-security-acl.yaml
@@ -1,0 +1,116 @@
+---
+openapi: 3.0.0
+
+info:
+  description: KongAir Flights service provides the scheduled flights for KongAir
+  version: 0.1.0
+  title: KongAir Flights
+
+x-kong-name: kongair-flights
+
+x-kong-mcp-default-acl:
+  - scope: tools
+    allow:
+      - "flights:read"
+
+servers:
+- url: https://mock-e91bb6429fe84bfeb970620df9499e52.mock.insomnia.run
+  description: KongAir API Server
+
+paths:
+  "/flights":
+    get:
+      security:
+        - okta_oauth2:
+            - flights:read
+      x-kong-mcp-tool-name: get-cool-flights
+      summary: Get KongAir planned flights
+      description: |
+        Returns all the scheduled flights for a given day
+      operationId: get-flights
+      parameters:
+        - name: date
+          in: query
+          description: Filter by date (defaults to current day)
+          required: false
+          schema:
+            type: string
+    post:
+      security:
+        - okta_oauth2:
+            - flights:write
+      summary: Create a new flight
+      description: |
+        Creates a new scheduled flight entry
+      operationId: create-flight
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - number
+                - route_id
+                - scheduled_departure
+                - scheduled_arrival
+              properties:
+                number:
+                  type: string
+                route_id:
+                  type: string
+                scheduled_departure:
+                  type: string
+                  format: date-time
+                scheduled_arrival:
+                  type: string
+                  format: date-time
+
+  "/flights/{flightNumber}":
+    get:
+      security:
+        - okta_oauth2:
+            - flights:read
+      summary: Get a specific flight by flight number
+      description: |
+        Returns a specific flight given its flight number
+      operationId: get-flight-by-number
+      parameters:
+        - name: flightNumber
+          in: path
+          description: The flight number
+          required: true
+          schema:
+            type: string
+
+  "/flights/{flightNumber}/details":
+    get:
+      security:
+        - okta_oauth2:
+            - flights:read
+      x-kong-mcp-exclude: true
+      summary: Fetch more details about a flight
+      description: Fetch more details about a flight
+      operationId: get-flight-details
+      parameters:
+      - name: flightNumber
+        in: path
+        description: The flight number
+        required: true
+        schema:
+          type: string
+
+components:
+  securitySchemes:
+    okta_oauth2:
+      type: oauth2
+      x-kong-mcp-acl:
+        acl_attribute_type: oauth_access_token
+        access_token_claim_field: scp
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.okta.com/oauth2/default/v1/authorize
+          tokenUrl: https://example.okta.com/oauth2/default/v1/token
+          scopes:
+            flights:read: Read access to flight resources
+            flights:write: Write access to flight resources

--- a/openapi2mcp/oas3_testfiles/invalid/no-paths.yaml
+++ b/openapi2mcp/oas3_testfiles/invalid/no-paths.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.0
+info:
+  title: No Paths API
+servers:
+  - url: https://api.example.com

--- a/openapi2mcp/openapi2mcp.go
+++ b/openapi2mcp/openapi2mcp.go
@@ -5,14 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-apiops/logbasics"
 	"github.com/kong/go-apiops/openapi2kong"
+	"github.com/kong/go-apiops/openapitools"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
 	openapibase "github.com/pb33f/libopenapi/datamodel/high/base"
@@ -60,158 +59,12 @@ func (opts *O2MOptions) setDefaults() {
 	}
 }
 
-// toKebabCase converts a string to kebab-case
-// Handles camelCase, PascalCase, snake_case, and existing kebab-case
-func toKebabCase(s string) string {
-	// First, replace underscores and spaces with hyphens
-	s = strings.ReplaceAll(s, "_", "-")
-	s = strings.ReplaceAll(s, " ", "-")
-
-	// Insert hyphens before uppercase letters (for camelCase/PascalCase)
-	re := regexp.MustCompile(`([a-z0-9])([A-Z])`)
-	s = re.ReplaceAllString(s, "${1}-${2}")
-
-	// Convert to lowercase
-	s = strings.ToLower(s)
-
-	// Remove any double hyphens
-	for strings.Contains(s, "--") {
-		s = strings.ReplaceAll(s, "--", "-")
-	}
-
-	// Trim leading/trailing hyphens
-	s = strings.Trim(s, "-")
-
-	return s
-}
-
-// getXKongComponents will return a map of the '/components/x-kong/' object.
-func getXKongComponents(doc v3.Document) (*map[string]interface{}, error) {
-	var components map[string]interface{}
-
-	if doc.Components == nil || doc.Components.Extensions == nil {
-		return &map[string]interface{}{}, nil
-	}
-
-	xKongComponents, ok := doc.Components.Extensions.Get("x-kong")
-	if !ok || xKongComponents == nil {
-		return &components, nil
-	}
-
-	xKongComponentsBytes, err := convertYamlNodeToBytes(xKongComponents)
-	if err != nil {
-		return nil, fmt.Errorf("expected '/components/x-kong' to be a YAML object")
-	}
-
-	var xKong interface{}
-	_ = yaml.Unmarshal(xKongComponentsBytes, &xKong)
-	components, err = jsonbasics.ToObject(xKong)
-	if err != nil {
-		return nil, fmt.Errorf("expected '/components/x-kong' to be a JSON/YAML object")
-	}
-
-	return &components, nil
-}
-
-// convertYamlNodeToBytes converts a YAML node to bytes
-func convertYamlNodeToBytes(node *yaml.Node) ([]byte, error) {
-	var data interface{}
-	err := node.Decode(&data)
-	if err != nil {
-		return nil, err
-	}
-	return yaml.Marshal(data)
-}
-
-// getXKongObject returns specified 'key' from the extension properties if available.
-func getXKongObject(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	key string,
-	components *map[string]interface{},
-) ([]byte, error) {
-	if extensions == nil {
-		return nil, nil
-	}
-
-	xKongObject, ok := extensions.Get(key)
-	if !ok || xKongObject == nil {
-		return nil, nil
-	}
-
-	xKongObjectBytes, err := convertYamlNodeToBytes(xKongObject)
-	if err != nil {
-		return nil, fmt.Errorf("expected '%s' to be a YAML object", key)
-	}
-
-	var jsonBlob interface{}
-	_ = yaml.Unmarshal(xKongObjectBytes, &jsonBlob)
-	jsonObject, err := jsonbasics.ToObject(jsonBlob)
-	if err != nil {
-		return nil, fmt.Errorf("expected '%s' to be a JSON/YAML object", key)
-	}
-
-	object, err := dereferenceJSONObject(jsonObject, components)
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(object)
-}
-
-// dereferenceJSONObject resolves $ref pointers within x-kong extensions
-func dereferenceJSONObject(
-	value map[string]interface{},
-	components *map[string]interface{},
-) (map[string]interface{}, error) {
-	var pointer string
-
-	switch value["$ref"].(type) {
-	case nil:
-		return value, nil
-	case string:
-		pointer = value["$ref"].(string)
-		if !strings.HasPrefix(pointer, "#/components/x-kong/") {
-			return nil, fmt.Errorf("all 'x-kong-...' references must be at '#/components/x-kong/...'")
-		}
-	default:
-		return nil, fmt.Errorf("expected '$ref' pointer to be a string")
-	}
-
-	segments := strings.Split(pointer, "/")
-	path := "#/components/x-kong"
-	result := components
-
-	for i := 3; i < len(segments); i++ {
-		segment := segments[i]
-		path = path + "/" + segment
-
-		switch (*result)[segment].(type) {
-		case nil:
-			return nil, fmt.Errorf("reference '%s' not found", pointer)
-		case map[string]interface{}:
-			target := (*result)[segment].(map[string]interface{})
-			result = &target
-		default:
-			return nil, fmt.Errorf("expected '%s' to be a JSON object", path)
-		}
-	}
-
-	return *result, nil
-}
-
-// getRouteDefaults returns a JSON string containing the route defaults
-func getRouteDefaults(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	components *map[string]interface{},
-) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-route-defaults", components)
-}
-
 // getMCPProxyConfig returns the x-kong-mcp-proxy override config
 func getMCPProxyConfig(
 	extensions *orderedmap.Map[string, *yaml.Node],
 	components *map[string]interface{},
 ) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-mcp-proxy", components)
+	return openapitools.GetXKongObject(extensions, "x-kong-mcp-proxy", components)
 }
 
 // getMCPACLConfig reads the x-kong-mcp-acl extension from a security scheme and returns the
@@ -226,7 +79,7 @@ func getMCPACLConfig(scheme *v3.SecurityScheme) (map[string]interface{}, error) 
 		return nil, nil
 	}
 
-	nodeBytes, err := convertYamlNodeToBytes(node)
+	nodeBytes, err := openapitools.ConvertYamlNodeToBytes(node)
 	if err != nil {
 		return nil, fmt.Errorf("expected 'x-kong-mcp-acl' to be a YAML object: %w", err)
 	}
@@ -252,7 +105,7 @@ func getMCPDefaultACL(extensions *orderedmap.Map[string, *yaml.Node]) ([]interfa
 		return nil, nil
 	}
 
-	nodeBytes, err := convertYamlNodeToBytes(node)
+	nodeBytes, err := openapitools.ConvertYamlNodeToBytes(node)
 	if err != nil {
 		return nil, fmt.Errorf("expected 'x-kong-mcp-default-acl' to be a YAML array: %w", err)
 	}
@@ -549,11 +402,11 @@ func buildMCPTool(
 		return nil, err
 	}
 	if toolName == "" {
-		toolName = toKebabCase(operation.OperationId)
+		toolName = openapitools.ToKebabCase(operation.OperationId)
 	}
 	if toolName == "" {
 		// Fallback: generate from method + path
-		toolName = toKebabCase(strings.ToLower(method) + "-" + strings.ReplaceAll(path, "/", "-"))
+		toolName = openapitools.ToKebabCase(strings.ToLower(method) + "-" + strings.ReplaceAll(path, "/", "-"))
 	}
 
 	// Get tool description: x-kong-mcp-tool-description > description > summary
@@ -687,11 +540,11 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 	routes := docService["routes"].([]interface{})
 
 	// get kong components and defaults
-	kongComponents, err := getXKongComponents(doc)
+	kongComponents, err := openapitools.GetXKongComponents(doc)
 	if err != nil {
 		return nil, err
 	}
-	docRouteDefaults, err := getRouteDefaults(doc.Extensions, kongComponents)
+	docRouteDefaults, err := openapitools.GetRouteDefaults(doc.Extensions, kongComponents)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi2mcp/openapi2mcp.go
+++ b/openapi2mcp/openapi2mcp.go
@@ -1,0 +1,1368 @@
+package openapi2mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/kong/go-apiops/jsonbasics"
+	"github.com/kong/go-apiops/logbasics"
+	"github.com/kong/go-slugify"
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
+	openapibase "github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"go.yaml.in/yaml/v4"
+)
+
+const (
+	formatVersionKey   = "_format_version"
+	formatVersionValue = "3.0"
+
+	// MCP proxy modes
+	ModeConversionListener = "conversion-listener"
+	ModeConversion         = "conversion"
+
+	// Default schemes
+	httpScheme  = "http"
+	httpsScheme = "https"
+)
+
+// O2MOptions defines the options for an OpenAPI to MCP conversion operation
+type O2MOptions struct {
+	// Array of tags to mark all generated entities with, taken from 'x-kong-tags' if omitted.
+	Tags []string
+	// Base document name, will be taken from x-kong-name, or info.title (for UUID generation!)
+	DocName string
+	// Namespace for UUID generation, defaults to DNS namespace for UUID v5
+	UUIDNamespace uuid.UUID
+	// Skip ID generation (UUIDs)
+	SkipID bool
+	// MCP proxy mode: "conversion" or "conversion-listener"
+	Mode string
+	// Custom path prefix for the MCP route (default: /{service-name}-mcp)
+	PathPrefix string
+	// Also generate direct (non-MCP) routes for API access
+	IncludeDirectRoute bool
+	// Ignore security errors (unsupported schemes, missing x-kong-mcp-acl extension)
+	IgnoreSecurityErrors bool
+}
+
+// setDefaults sets the defaults for the OpenAPI2MCP operation.
+func (opts *O2MOptions) setDefaults() {
+	var emptyUUID uuid.UUID
+
+	if bytes.Equal(emptyUUID[:], opts.UUIDNamespace[:]) {
+		opts.UUIDNamespace = uuid.NameSpaceDNS
+	}
+
+	if opts.Mode == "" {
+		opts.Mode = ModeConversionListener
+	}
+}
+
+// Slugify converts a name to a valid Kong name by removing and replacing unallowed characters
+// and sanitizing non-latin characters. Multiple inputs will be concatenated using '_'.
+func Slugify(name ...string) string {
+	slugifier := (&slugify.Slugifier{}).ToLower(true).InvalidChar("-").WordSeparator("-")
+	concatBy := "_"
+
+	for i, elem := range name {
+		name[i] = slugifier.Slugify(elem)
+	}
+
+	// drop empty strings from the array
+	for i := 0; i < len(name); i++ {
+		if name[i] == "" {
+			name = append(name[:i], name[i+1:]...)
+			i--
+		}
+	}
+
+	return strings.Join(name, concatBy)
+}
+
+// toKebabCase converts a string to kebab-case
+// Handles camelCase, PascalCase, snake_case, and existing kebab-case
+func toKebabCase(s string) string {
+	// First, replace underscores and spaces with hyphens
+	s = strings.ReplaceAll(s, "_", "-")
+	s = strings.ReplaceAll(s, " ", "-")
+
+	// Insert hyphens before uppercase letters (for camelCase/PascalCase)
+	re := regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	s = re.ReplaceAllString(s, "${1}-${2}")
+
+	// Convert to lowercase
+	s = strings.ToLower(s)
+
+	// Remove any double hyphens
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+
+	// Trim leading/trailing hyphens
+	s = strings.Trim(s, "-")
+
+	return s
+}
+
+// getKongTags returns the provided tags or if nil, then the `x-kong-tags` property,
+// validated to be a string array.
+func getKongTags(doc v3.Document, tagsProvided []string) ([]string, error) {
+	if tagsProvided != nil {
+		return tagsProvided, nil
+	}
+
+	if doc.Extensions == nil {
+		return make([]string, 0), nil
+	}
+
+	kongTags, ok := doc.Extensions.Get("x-kong-tags")
+	if !ok {
+		return make([]string, 0), nil
+	}
+
+	resultArray := make([]string, len(kongTags.Content))
+	for i, v := range kongTags.Content {
+		var tagsValue interface{}
+		err := yaml.Unmarshal([]byte(v.Value), &tagsValue)
+		if err != nil {
+			return nil, fmt.Errorf("expected 'x-kong-tags' to be an array of strings: %w", err)
+		}
+
+		switch tag := tagsValue.(type) {
+		case string:
+			resultArray[i] = tag
+		default:
+			return nil, fmt.Errorf("expected 'x-kong-tags' to be an array of strings")
+		}
+	}
+
+	return resultArray, nil
+}
+
+// getKongName returns the `x-kong-name` property, validated to be a string
+func getKongName(extensions *orderedmap.Map[string, *yaml.Node]) (string, error) {
+	if extensions == nil {
+		return "", nil
+	}
+
+	xKongName, ok := extensions.Get("x-kong-name")
+	if !ok {
+		return "", nil
+	}
+
+	var name string
+	err := yaml.Unmarshal([]byte(xKongName.Value), &name)
+	if err != nil {
+		return "", fmt.Errorf("expected 'x-kong-name' to be a string: %w", err)
+	}
+
+	return name, nil
+}
+
+// getXKongComponents will return a map of the '/components/x-kong/' object.
+func getXKongComponents(doc v3.Document) (*map[string]interface{}, error) {
+	var components map[string]interface{}
+
+	if doc.Components == nil || doc.Components.Extensions == nil {
+		return &map[string]interface{}{}, nil
+	}
+
+	xKongComponents, ok := doc.Components.Extensions.Get("x-kong")
+	if !ok || xKongComponents == nil {
+		return &components, nil
+	}
+
+	xKongComponentsBytes, err := convertYamlNodeToBytes(xKongComponents)
+	if err != nil {
+		return nil, fmt.Errorf("expected '/components/x-kong' to be a YAML object")
+	}
+
+	var xKong interface{}
+	_ = yaml.Unmarshal(xKongComponentsBytes, &xKong)
+	components, err = jsonbasics.ToObject(xKong)
+	if err != nil {
+		return nil, fmt.Errorf("expected '/components/x-kong' to be a JSON/YAML object")
+	}
+
+	return &components, nil
+}
+
+// convertYamlNodeToBytes converts a YAML node to bytes
+func convertYamlNodeToBytes(node *yaml.Node) ([]byte, error) {
+	var data interface{}
+	err := node.Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(data)
+}
+
+// getXKongObject returns specified 'key' from the extension properties if available.
+func getXKongObject(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	key string,
+	components *map[string]interface{},
+) ([]byte, error) {
+	if extensions == nil {
+		return nil, nil
+	}
+
+	xKongObject, ok := extensions.Get(key)
+	if !ok || xKongObject == nil {
+		return nil, nil
+	}
+
+	xKongObjectBytes, err := convertYamlNodeToBytes(xKongObject)
+	if err != nil {
+		return nil, fmt.Errorf("expected '%s' to be a YAML object", key)
+	}
+
+	var jsonBlob interface{}
+	_ = yaml.Unmarshal(xKongObjectBytes, &jsonBlob)
+	jsonObject, err := jsonbasics.ToObject(jsonBlob)
+	if err != nil {
+		return nil, fmt.Errorf("expected '%s' to be a JSON/YAML object", key)
+	}
+
+	object, err := dereferenceJSONObject(jsonObject, components)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(object)
+}
+
+// dereferenceJSONObject resolves $ref pointers within x-kong extensions
+func dereferenceJSONObject(
+	value map[string]interface{},
+	components *map[string]interface{},
+) (map[string]interface{}, error) {
+	var pointer string
+
+	switch value["$ref"].(type) {
+	case nil:
+		return value, nil
+	case string:
+		pointer = value["$ref"].(string)
+		if !strings.HasPrefix(pointer, "#/components/x-kong/") {
+			return nil, fmt.Errorf("all 'x-kong-...' references must be at '#/components/x-kong/...'")
+		}
+	default:
+		return nil, fmt.Errorf("expected '$ref' pointer to be a string")
+	}
+
+	segments := strings.Split(pointer, "/")
+	path := "#/components/x-kong"
+	result := components
+
+	for i := 3; i < len(segments); i++ {
+		segment := segments[i]
+		path = path + "/" + segment
+
+		switch (*result)[segment].(type) {
+		case nil:
+			return nil, fmt.Errorf("reference '%s' not found", pointer)
+		case map[string]interface{}:
+			target := (*result)[segment].(map[string]interface{})
+			result = &target
+		default:
+			return nil, fmt.Errorf("expected '%s' to be a JSON object", path)
+		}
+	}
+
+	return *result, nil
+}
+
+// getServiceDefaults returns a JSON string containing the service defaults
+func getServiceDefaults(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	components *map[string]interface{},
+) ([]byte, error) {
+	return getXKongObject(extensions, "x-kong-service-defaults", components)
+}
+
+// getRouteDefaults returns a JSON string containing the route defaults
+func getRouteDefaults(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	components *map[string]interface{},
+) ([]byte, error) {
+	return getXKongObject(extensions, "x-kong-route-defaults", components)
+}
+
+// getUpstreamDefaults returns a JSON string containing the upstream defaults
+func getUpstreamDefaults(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	components *map[string]interface{},
+) ([]byte, error) {
+	return getXKongObject(extensions, "x-kong-upstream-defaults", components)
+}
+
+// getMCPProxyConfig returns the x-kong-mcp-proxy override config
+func getMCPProxyConfig(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	components *map[string]interface{},
+) ([]byte, error) {
+	return getXKongObject(extensions, "x-kong-mcp-proxy", components)
+}
+
+// getMCPACLConfig reads the x-kong-mcp-acl extension from a security scheme and returns the
+// ACL configuration (acl_attribute_type, access_token_claim_field).
+func getMCPACLConfig(scheme *v3.SecurityScheme) (map[string]interface{}, error) {
+	if scheme == nil || scheme.Extensions == nil {
+		return nil, nil
+	}
+
+	node, ok := scheme.Extensions.Get("x-kong-mcp-acl")
+	if !ok || node == nil {
+		return nil, nil
+	}
+
+	nodeBytes, err := convertYamlNodeToBytes(node)
+	if err != nil {
+		return nil, fmt.Errorf("expected 'x-kong-mcp-acl' to be a YAML object: %w", err)
+	}
+
+	var aclConfig map[string]interface{}
+	err = yaml.Unmarshal(nodeBytes, &aclConfig)
+	if err != nil {
+		return nil, fmt.Errorf("expected 'x-kong-mcp-acl' to be a YAML object: %w", err)
+	}
+
+	return aclConfig, nil
+}
+
+// getMCPDefaultACL reads the x-kong-mcp-default-acl extension from document-level extensions
+// and returns the default ACL array (e.g. [{scope: "tools", allow: ["flights:read"]}]).
+func getMCPDefaultACL(extensions *orderedmap.Map[string, *yaml.Node]) ([]interface{}, error) {
+	if extensions == nil {
+		return nil, nil
+	}
+
+	node, ok := extensions.Get("x-kong-mcp-default-acl")
+	if !ok || node == nil {
+		return nil, nil
+	}
+
+	nodeBytes, err := convertYamlNodeToBytes(node)
+	if err != nil {
+		return nil, fmt.Errorf("expected 'x-kong-mcp-default-acl' to be a YAML array: %w", err)
+	}
+
+	var defaultACL []interface{}
+	err = yaml.Unmarshal(nodeBytes, &defaultACL)
+	if err != nil {
+		return nil, fmt.Errorf("expected 'x-kong-mcp-default-acl' to be a YAML array: %w", err)
+	}
+
+	return defaultACL, nil
+}
+
+// getOperationACL extracts ACL scopes from an operation's security requirements.
+// If the operation has no security field, it inherits from document-level security.
+// Returns a map with "allow" key containing sorted scope strings, or nil if no security applies.
+func getOperationACL(
+	operationSecurity []*openapibase.SecurityRequirement,
+	docSecurity []*openapibase.SecurityRequirement,
+	doc v3.Document,
+	ignoreSecurityErrors bool,
+) (map[string]interface{}, error) {
+	// Determine effective security: operation-level overrides document-level
+	security := operationSecurity
+	if security == nil {
+		// No operation-level security; inherit from document
+		security = docSecurity
+	}
+
+	if len(security) == 0 {
+		// No security requirements at all
+		return nil, nil
+	}
+
+	// Check for explicit empty security (security: []) which opts out
+	if len(security) == 1 && security[0].ContainsEmptyRequirement {
+		return nil, nil
+	}
+
+	if len(security) > 1 {
+		// Multiple security requirements represent OR logic
+		if ignoreSecurityErrors {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("only a single security requirement is supported per operation for MCP ACL generation")
+	}
+
+	requirement := security[0].Requirements
+	if requirement == nil || requirement.Len() == 0 {
+		return nil, nil
+	}
+
+	if requirement.Len() > 1 {
+		// Multiple schemes within one requirement is AND logic
+		if ignoreSecurityErrors {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("only a single security scheme per requirement is supported for MCP ACL generation")
+	}
+
+	// Extract the single scheme name and scopes
+	reqPair := requirement.First()
+	schemeName := reqPair.Key()
+	scopes := reqPair.Value()
+
+	// Validate the scheme exists and is oauth2
+	if doc.Components == nil || doc.Components.SecuritySchemes == nil {
+		if ignoreSecurityErrors {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("no security schemes defined in components")
+	}
+
+	scheme, ok := doc.Components.SecuritySchemes.Get(schemeName)
+	if !ok || scheme == nil {
+		if ignoreSecurityErrors {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("security scheme '%s' not found in components/securitySchemes", schemeName)
+	}
+
+	if strings.ToLower(scheme.Type) != "oauth2" {
+		if ignoreSecurityErrors {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("only 'oauth2' security schemes are supported for MCP ACL generation, got '%s'", scheme.Type)
+	}
+
+	// Validate the scheme has x-kong-mcp-acl extension
+	aclConfig, err := getMCPACLConfig(scheme)
+	if err != nil {
+		return nil, err
+	}
+	if aclConfig == nil {
+		if ignoreSecurityErrors {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("oauth2 security scheme '%s' is missing the 'x-kong-mcp-acl' extension", schemeName)
+	}
+
+	if len(scopes) == 0 {
+		return nil, nil
+	}
+
+	// Sort scopes for deterministic output
+	sortedScopes := make([]string, len(scopes))
+	copy(sortedScopes, scopes)
+	sort.Strings(sortedScopes)
+
+	return map[string]interface{}{
+		"allow": sortedScopes,
+	}, nil
+}
+
+// findACLSecurityScheme looks through the document's security schemes for the first oauth2 scheme
+// that has an x-kong-mcp-acl extension. Returns the scheme and its ACL config, or nil if none found.
+func findACLSecurityScheme(doc v3.Document) (*v3.SecurityScheme, map[string]interface{}, error) {
+	if doc.Components == nil || doc.Components.SecuritySchemes == nil {
+		return nil, nil, nil
+	}
+
+	for pair := doc.Components.SecuritySchemes.First(); pair != nil; pair = pair.Next() {
+		scheme := pair.Value()
+		if scheme == nil || strings.ToLower(scheme.Type) != "oauth2" {
+			continue
+		}
+
+		aclConfig, err := getMCPACLConfig(scheme)
+		if err != nil {
+			return nil, nil, err
+		}
+		if aclConfig != nil {
+			return scheme, aclConfig, nil
+		}
+	}
+
+	return nil, nil, nil
+}
+
+// getExtensionBool returns a boolean value from an extension
+func getExtensionBool(extensions *orderedmap.Map[string, *yaml.Node], key string) (bool, error) {
+	if extensions == nil {
+		return false, nil
+	}
+
+	node, ok := extensions.Get(key)
+	if !ok || node == nil {
+		return false, nil
+	}
+
+	var value bool
+	err := yaml.Unmarshal([]byte(node.Value), &value)
+	if err != nil {
+		return false, fmt.Errorf("expected '%s' to be a boolean: %w", key, err)
+	}
+
+	return value, nil
+}
+
+// getExtensionString returns a string value from an extension
+func getExtensionString(extensions *orderedmap.Map[string, *yaml.Node], key string) (string, error) {
+	if extensions == nil {
+		return "", nil
+	}
+
+	node, ok := extensions.Get(key)
+	if !ok || node == nil {
+		return "", nil
+	}
+
+	var value string
+	err := yaml.Unmarshal([]byte(node.Value), &value)
+	if err != nil {
+		return "", fmt.Errorf("expected '%s' to be a string: %w", key, err)
+	}
+
+	return value, nil
+}
+
+// getPluginsList returns a list of plugins from x-kong-plugin-* extensions
+func getPluginsList(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	uuidNamespace uuid.UUID,
+	baseName string,
+	components *map[string]interface{},
+	tags []string,
+	skipID bool,
+) ([]*map[string]interface{}, error) {
+	plugins := make(map[string]*map[string]interface{})
+
+	if extensions == nil {
+		return make([]*map[string]interface{}, 0), nil
+	}
+
+	extension := extensions.First()
+	for extension != nil {
+		extensionName := extension.Key()
+		if strings.HasPrefix(extensionName, "x-kong-plugin-") {
+			pluginName := strings.TrimPrefix(extensionName, "x-kong-plugin-")
+
+			jsonstr, err := getXKongObject(extensions, extensionName, components)
+			if err != nil {
+				return nil, err
+			}
+
+			var pluginConfig map[string]interface{}
+			err = json.Unmarshal(jsonstr, &pluginConfig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse JSON object for '%s': %w", extensionName, err)
+			}
+
+			pluginConfig["name"] = pluginName
+			if !skipID {
+				pluginConfig["id"] = uuid.NewSHA1(uuidNamespace, []byte(baseName+".plugin."+pluginName)).String()
+			}
+			pluginConfig["tags"] = tags
+
+			delete(pluginConfig, "service")
+			delete(pluginConfig, "route")
+
+			plugins[pluginName] = &pluginConfig
+		}
+
+		extension = extension.Next()
+	}
+
+	// Sort plugins by name for deterministic output
+	sortedNames := make([]string, 0, len(plugins))
+	for pluginName := range plugins {
+		sortedNames = append(sortedNames, pluginName)
+	}
+	sort.Strings(sortedNames)
+
+	sorted := make([]*map[string]interface{}, len(plugins))
+	for i, pluginName := range sortedNames {
+		sorted[i] = plugins[pluginName]
+	}
+	return sorted, nil
+}
+
+// parseServerUris parses the server URIs after rendering template variables
+func parseServerUris(servers []*v3.Server) ([]*url.URL, error) {
+	var targets []*url.URL
+
+	if len(servers) == 0 {
+		uriObject, _ := url.ParseRequestURI("/")
+		targets = make([]*url.URL, 1)
+		targets[0] = uriObject
+	} else {
+		targets = make([]*url.URL, len(servers))
+
+		for i, server := range servers {
+			uriString := server.URL
+
+			pair := server.Variables.First()
+			for pair != nil {
+				name := pair.Key()
+				svar := pair.Value()
+				uriString = strings.ReplaceAll(uriString, "{"+name+"}", svar.Default)
+				pair = pair.Next()
+			}
+
+			uriObject, err := url.ParseRequestURI(uriString)
+			if err != nil {
+				return targets, fmt.Errorf("failed to parse uri '%s'; %w", uriString, err)
+			}
+
+			if uriObject.Path == "" {
+				uriObject.Path = "/"
+			}
+
+			targets[i] = uriObject
+		}
+	}
+
+	return targets, nil
+}
+
+// setServerDefaults sets the scheme and port if missing
+func setServerDefaults(targets []*url.URL, schemeDefault string) {
+	for _, target := range targets {
+		if target.Host == "" {
+			target.Host = "localhost"
+		}
+
+		if target.Scheme == "" {
+			switch target.Port() {
+			case "80":
+				target.Scheme = httpScheme
+			case "443":
+				target.Scheme = httpsScheme
+			default:
+				target.Scheme = schemeDefault
+			}
+		}
+
+		if target.Host != "" && target.Port() == "" {
+			if target.Scheme == httpScheme {
+				target.Host = target.Host + ":80"
+			}
+			if target.Scheme == httpsScheme {
+				target.Host = target.Host + ":443"
+			}
+		}
+	}
+}
+
+// createKongUpstream creates a new upstream entity
+func createKongUpstream(
+	baseName string,
+	servers []*v3.Server,
+	upstreamDefaults []byte,
+	tags []string,
+	uuidNamespace uuid.UUID,
+	skipID bool,
+) (map[string]interface{}, error) {
+	var upstream map[string]interface{}
+
+	if upstreamDefaults != nil {
+		_ = json.Unmarshal(upstreamDefaults, &upstream)
+	} else {
+		upstream = make(map[string]interface{})
+	}
+
+	upstreamName := baseName + ".upstream"
+	if !skipID {
+		upstream["id"] = uuid.NewSHA1(uuidNamespace, []byte(upstreamName)).String()
+	}
+	upstream["name"] = upstreamName
+	upstream["tags"] = tags
+
+	targets, err := parseServerUris(servers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate upstream: %w", err)
+	}
+
+	setServerDefaults(targets, httpsScheme)
+
+	upstreamTargets := make([]map[string]interface{}, len(targets))
+	for i, target := range targets {
+		t := make(map[string]interface{})
+		t["target"] = target.Host
+		t["tags"] = tags
+		upstreamTargets[i] = t
+	}
+	upstream["targets"] = upstreamTargets
+
+	return upstream, nil
+}
+
+// CreateKongService creates a new Kong service entity, and optional upstream
+func CreateKongService(
+	baseName string,
+	servers []*v3.Server,
+	serviceDefaults []byte,
+	upstreamDefaults []byte,
+	tags []string,
+	uuidNamespace uuid.UUID,
+	skipID bool,
+) (map[string]interface{}, map[string]interface{}, error) {
+	var (
+		service  map[string]interface{}
+		upstream map[string]interface{}
+	)
+
+	if serviceDefaults != nil {
+		_ = json.Unmarshal(serviceDefaults, &service)
+	} else {
+		service = make(map[string]interface{})
+	}
+
+	if !skipID {
+		service["id"] = uuid.NewSHA1(uuidNamespace, []byte(baseName+".service")).String()
+	}
+	service["name"] = baseName
+	service["tags"] = tags
+	service["plugins"] = make([]interface{}, 0)
+	service["routes"] = make([]interface{}, 0)
+
+	targets, err := parseServerUris(servers)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create service: %w", err)
+	}
+
+	scheme := httpsScheme
+	if service["protocol"] != nil {
+		scheme = service["protocol"].(string)
+	}
+	setServerDefaults(targets, scheme)
+
+	if service["protocol"] == nil {
+		scheme = targets[0].Scheme
+		service["protocol"] = scheme
+	}
+	if service["path"] == nil {
+		service["path"] = targets[0].Path
+	}
+	if service["port"] == nil {
+		if targets[0].Port() != "" {
+			parsedPort, err := strconv.ParseUint(targets[0].Port(), 10, 16)
+			if err != nil {
+				return nil, nil, err
+			}
+			service["port"] = parsedPort
+		} else {
+			if scheme != httpScheme {
+				service["port"] = 443
+			} else {
+				service["port"] = 80
+			}
+		}
+	}
+
+	if service["host"] == nil {
+		if len(targets) == 1 && upstreamDefaults == nil {
+			service["host"] = targets[0].Hostname()
+		} else {
+			upstream, err = createKongUpstream(baseName, servers, upstreamDefaults, tags, uuidNamespace, skipID)
+			if err != nil {
+				return nil, nil, err
+			}
+			service["host"] = upstream["name"]
+		}
+	}
+
+	return service, upstream, nil
+}
+
+// simplifySchema simplifies an OpenAPI schema to essential properties
+func simplifySchema(schema *openapibase.Schema) map[string]interface{} {
+	if schema == nil {
+		return nil
+	}
+
+	result := make(map[string]interface{})
+
+	// Handle type
+	if len(schema.Type) > 0 {
+		result["type"] = schema.Type[0]
+	}
+
+	// For objects, include properties and required
+	if result["type"] == "object" && schema.Properties != nil {
+		props := make(map[string]interface{})
+		for pair := schema.Properties.First(); pair != nil; pair = pair.Next() {
+			propSchema := pair.Value().Schema()
+			props[pair.Key()] = simplifySchema(propSchema)
+		}
+		result["properties"] = props
+
+		if len(schema.Required) > 0 {
+			result["required"] = schema.Required
+		}
+	}
+
+	// For arrays, include items
+	if result["type"] == "array" && schema.Items != nil && schema.Items.A != nil {
+		result["items"] = simplifySchema(schema.Items.A.Schema())
+	}
+
+	return result
+}
+
+// buildParameters builds the parameters array for an MCP tool
+func buildParameters(params []*v3.Parameter) []map[string]interface{} {
+	if len(params) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(params))
+	for _, param := range params {
+		if param == nil {
+			continue
+		}
+
+		p := map[string]interface{}{
+			"name":     param.Name,
+			"in":       param.In,
+			"required": param.Required != nil && *param.Required,
+		}
+
+		if param.Description != "" {
+			p["description"] = param.Description
+		}
+
+		if param.Schema != nil {
+			schema := param.Schema.Schema()
+			if schema != nil {
+				p["schema"] = simplifySchema(schema)
+			}
+		}
+
+		result = append(result, p)
+	}
+
+	return result
+}
+
+// buildRequestBody builds the request_body object for an MCP tool
+func buildRequestBody(rb *v3.RequestBody) map[string]interface{} {
+	if rb == nil {
+		return nil
+	}
+
+	result := map[string]interface{}{}
+
+	if rb.Required != nil {
+		result["required"] = *rb.Required
+	}
+
+	if rb.Content != nil {
+		content := make(map[string]interface{})
+		for pair := rb.Content.First(); pair != nil; pair = pair.Next() {
+			mediaType := pair.Key()
+			mediaTypeObj := pair.Value()
+
+			mediaContent := make(map[string]interface{})
+			if mediaTypeObj.Schema != nil {
+				schema := mediaTypeObj.Schema.Schema()
+				if schema != nil {
+					mediaContent["schema"] = simplifySchema(schema)
+				}
+			}
+			content[mediaType] = mediaContent
+		}
+		result["content"] = content
+	}
+
+	return result
+}
+
+// buildMCPTool builds an MCP tool definition from an OAS operation
+func buildMCPTool(
+	path string,
+	method string,
+	operation *v3.Operation,
+	pathParams []*v3.Parameter,
+	acl map[string]interface{},
+) (map[string]interface{}, error) {
+	// Get tool name: x-kong-mcp-tool-name > operationId
+	toolName, err := getExtensionString(operation.Extensions, "x-kong-mcp-tool-name")
+	if err != nil {
+		return nil, err
+	}
+	if toolName == "" {
+		toolName = toKebabCase(operation.OperationId)
+	}
+	if toolName == "" {
+		// Fallback: generate from method + path
+		toolName = toKebabCase(strings.ToLower(method) + "-" + strings.ReplaceAll(path, "/", "-"))
+	}
+
+	// Get tool description: x-kong-mcp-tool-description > description > summary
+	toolDesc, err := getExtensionString(operation.Extensions, "x-kong-mcp-tool-description")
+	if err != nil {
+		return nil, err
+	}
+	if toolDesc == "" {
+		if operation.Description != "" {
+			toolDesc = operation.Description
+		} else if operation.Summary != "" {
+			toolDesc = operation.Summary
+		}
+	}
+
+	tool := map[string]interface{}{
+		"name":   toolName,
+		"method": strings.ToUpper(method),
+		"path":   path,
+	}
+
+	if toolDesc != "" {
+		tool["description"] = toolDesc
+	}
+
+	// Add annotations with title
+	if operation.Summary != "" {
+		tool["annotations"] = map[string]interface{}{
+			"title": operation.Summary,
+		}
+	}
+
+	// Merge path-level and operation-level parameters
+	allParams := make([]*v3.Parameter, 0)
+	paramNames := make(map[string]bool)
+
+	// Operation params take precedence
+	for _, p := range operation.Parameters {
+		if p != nil {
+			allParams = append(allParams, p)
+			paramNames[p.Name] = true
+		}
+	}
+
+	// Add path params that aren't overridden
+	for _, p := range pathParams {
+		if p != nil && !paramNames[p.Name] {
+			allParams = append(allParams, p)
+		}
+	}
+
+	if len(allParams) > 0 {
+		tool["parameters"] = buildParameters(allParams)
+	}
+
+	// Add request body
+	if operation.RequestBody != nil {
+		tool["request_body"] = buildRequestBody(operation.RequestBody)
+	}
+
+	// Add ACL if provided
+	if acl != nil {
+		tool["acl"] = acl
+	}
+
+	return tool, nil
+}
+
+// MustConvert is the same as Convert, but will panic if an error is returned.
+func MustConvert(content []byte, opts O2MOptions) map[string]interface{} {
+	result, err := Convert(content, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return result
+}
+
+// Convert converts an OpenAPI spec to a Kong declarative file with MCP configuration.
+func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
+	opts.setDefaults()
+	logbasics.Debug("received OpenAPI2MCP options", "options", opts)
+
+	// Set up output document
+	result := make(map[string]interface{})
+	result[formatVersionKey] = formatVersionValue
+	services := make([]interface{}, 0)
+	upstreams := make([]interface{}, 0)
+
+	var (
+		err            error
+		doc            v3.Document
+		kongComponents *map[string]interface{}
+		kongTags       []string
+
+		docBaseName         string
+		docServers          []*v3.Server
+		docServiceDefaults  []byte
+		docUpstreamDefaults []byte
+		docRouteDefaults    []byte
+		docService          map[string]interface{}
+		docUpstream         map[string]interface{}
+	)
+
+	// Load and parse the OAS file
+	openapiDoc, err := libopenapi.NewDocument(content)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing OAS3 file: [%w]", err)
+	}
+
+	// Configure document options
+	docConfig := datamodel.NewDocumentConfiguration()
+	docConfig.IgnoreArrayCircularReferences = true
+	docConfig.IgnorePolymorphicCircularReferences = true
+	openapiDoc.SetConfiguration(docConfig)
+
+	v3Model, errs := openapiDoc.BuildV3Model()
+	if errs != nil {
+		logbasics.Error(errs, "error while building v3 document model")
+		return nil, fmt.Errorf("cannot create v3 model from document: %w", errs)
+	}
+
+	if v3Model != nil {
+		doc = v3Model.Model
+	}
+
+	// Collect tags
+	if kongTags, err = getKongTags(doc, opts.Tags); err != nil {
+		return nil, err
+	}
+
+	// Set document level elements
+	docServers = doc.Servers
+
+	// Determine document name
+	docBaseName = opts.DocName
+	if docBaseName == "" {
+		if docBaseName, err = getKongName(doc.Extensions); err != nil {
+			return nil, err
+		}
+		if docBaseName == "" {
+			if doc.Info != nil && doc.Info.Title != "" {
+				docBaseName = doc.Info.Title
+			} else {
+				id, err := uuid.NewRandom()
+				if err != nil {
+					return nil, fmt.Errorf("failed to generate UUID: %w", err)
+				}
+				docBaseName = id.String()
+			}
+		}
+	}
+	docBaseName = Slugify(docBaseName)
+
+	if kongComponents, err = getXKongComponents(doc); err != nil {
+		return nil, err
+	}
+
+	// Get defaults
+	if docServiceDefaults, err = getServiceDefaults(doc.Extensions, kongComponents); err != nil {
+		return nil, err
+	}
+	if docUpstreamDefaults, err = getUpstreamDefaults(doc.Extensions, kongComponents); err != nil {
+		return nil, err
+	}
+	if docRouteDefaults, err = getRouteDefaults(doc.Extensions, kongComponents); err != nil {
+		return nil, err
+	}
+
+	// Create the Kong service and optional upstream
+	docService, docUpstream, err = CreateKongService(
+		docBaseName,
+		docServers,
+		docServiceDefaults,
+		docUpstreamDefaults,
+		kongTags,
+		opts.UUIDNamespace,
+		opts.SkipID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create service/upstream: %w", err)
+	}
+
+	services = append(services, docService)
+	if docUpstream != nil {
+		upstreams = append(upstreams, docUpstream)
+	}
+
+	// Get document-level plugins
+	docPlugins, err := getPluginsList(
+		doc.Extensions, opts.UUIDNamespace, docBaseName, kongComponents, kongTags, opts.SkipID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get plugins list: %w", err)
+	}
+	docService["plugins"] = docPlugins
+
+	// Check for paths
+	if doc.Paths == nil {
+		return nil, fmt.Errorf("must have `.paths` in the root of the document")
+	}
+
+	// Detect ACL security configuration
+	// If any oauth2 security scheme has x-kong-mcp-acl, we'll generate ACL entries
+	_, aclConfig, err := findACLSecurityScheme(doc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read security scheme ACL config: %w", err)
+	}
+
+	// Read default ACL from document-level extension
+	var defaultACL []interface{}
+	if aclConfig != nil {
+		defaultACL, err = getMCPDefaultACL(doc.Extensions)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read default ACL: %w", err)
+		}
+	}
+
+	// Build MCP tools from all operations
+	tools := make([]interface{}, 0)
+
+	// Create sorted array of paths for deterministic output
+	allPaths := doc.Paths.PathItems
+	sortedPaths := make([]string, 0, allPaths.Len())
+	path := allPaths.First()
+	for path != nil {
+		sortedPaths = append(sortedPaths, path.Key())
+		path = path.Next()
+	}
+	sort.Strings(sortedPaths)
+
+	for _, pathKey := range sortedPaths {
+		pathItem, ok := allPaths.Get(pathKey)
+		if !ok {
+			continue
+		}
+
+		operations := pathItem.GetOperations()
+		sortedMethods := make([]string, 0, operations.Len())
+		method := operations.First()
+		for method != nil {
+			sortedMethods = append(sortedMethods, method.Key())
+			method = method.Next()
+		}
+		sort.Strings(sortedMethods)
+
+		for _, methodKey := range sortedMethods {
+			operation, ok := operations.Get(methodKey)
+			if !ok {
+				continue
+			}
+
+			// Check if operation is excluded
+			excluded, err := getExtensionBool(operation.Extensions, "x-kong-mcp-exclude")
+			if err != nil {
+				return nil, err
+			}
+			if excluded {
+				continue
+			}
+
+			// Get per-tool ACL from security requirements
+			var toolACL map[string]interface{}
+			if aclConfig != nil {
+				toolACL, err = getOperationACL(operation.Security, doc.Security, doc, opts.IgnoreSecurityErrors)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get ACL for %s %s: %w", methodKey, pathKey, err)
+				}
+			}
+
+			tool, err := buildMCPTool(pathKey, methodKey, operation, pathItem.Parameters, toolACL)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build MCP tool for %s %s: %w", methodKey, pathKey, err)
+			}
+
+			tools = append(tools, tool)
+		}
+	}
+
+	// Build the MCP route
+	mcpRouteName := docBaseName + "-mcp"
+	mcpRoutePath := opts.PathPrefix
+	if mcpRoutePath == "" {
+		mcpRoutePath = "/" + mcpRouteName
+	}
+
+	mcpRoute := make(map[string]interface{})
+	if docRouteDefaults != nil {
+		_ = json.Unmarshal(docRouteDefaults, &mcpRoute)
+		delete(mcpRoute, "service")
+	}
+
+	if !opts.SkipID {
+		mcpRoute["id"] = uuid.NewSHA1(opts.UUIDNamespace, []byte(mcpRouteName+".route")).String()
+	}
+	mcpRoute["name"] = mcpRouteName
+	mcpRoute["paths"] = []string{mcpRoutePath}
+	mcpRoute["tags"] = kongTags
+
+	// Build ai-mcp-proxy plugin config
+	mcpPluginConfig := map[string]interface{}{
+		"mode":  opts.Mode,
+		"tools": tools,
+	}
+
+	// Add ACL configuration to plugin config if security was detected
+	if aclConfig != nil {
+		if v, ok := aclConfig["acl_attribute_type"]; ok {
+			mcpPluginConfig["acl_attribute_type"] = v
+		}
+		if v, ok := aclConfig["access_token_claim_field"]; ok {
+			mcpPluginConfig["access_token_claim_field"] = v
+		}
+	}
+	if defaultACL != nil {
+		mcpPluginConfig["default_acl"] = defaultACL
+	}
+
+	// Check for x-kong-mcp-proxy override
+	mcpProxyOverride, err := getMCPProxyConfig(doc.Extensions, kongComponents)
+	if err != nil {
+		return nil, err
+	}
+	if mcpProxyOverride != nil {
+		var override map[string]interface{}
+		_ = json.Unmarshal(mcpProxyOverride, &override)
+		// Merge override into config (override takes precedence except for tools)
+		for k, v := range override {
+			if k != "tools" { // Don't override generated tools
+				mcpPluginConfig[k] = v
+			}
+		}
+	}
+
+	mcpPlugin := map[string]interface{}{
+		"name":   "ai-mcp-proxy",
+		"config": mcpPluginConfig,
+	}
+
+	if !opts.SkipID {
+		mcpPlugin["id"] = uuid.NewSHA1(opts.UUIDNamespace, []byte(mcpRouteName+".plugin.ai-mcp-proxy")).String()
+	}
+	mcpPlugin["tags"] = kongTags
+
+	mcpRoute["plugins"] = []interface{}{mcpPlugin}
+
+	// Add MCP route to service
+	routes := docService["routes"].([]interface{})
+	routes = append(routes, mcpRoute)
+
+	// Optionally add direct routes (non-MCP)
+	if opts.IncludeDirectRoute {
+		directRoutes := buildDirectRoutes(doc, docBaseName, docRouteDefaults, kongTags, opts.UUIDNamespace, opts.SkipID)
+		routes = append(routes, directRoutes...)
+	}
+
+	docService["routes"] = routes
+
+	// Build result
+	result["services"] = services
+	if len(upstreams) > 0 {
+		result["upstreams"] = upstreams
+	}
+
+	return result, nil
+}
+
+// buildDirectRoutes builds traditional Kong routes for direct API access (non-MCP)
+func buildDirectRoutes(
+	doc v3.Document,
+	baseName string,
+	routeDefaults []byte,
+	tags []string,
+	uuidNamespace uuid.UUID,
+	skipID bool,
+) []interface{} {
+	routes := make([]interface{}, 0)
+
+	if doc.Paths == nil {
+		return routes
+	}
+
+	allPaths := doc.Paths.PathItems
+	sortedPaths := make([]string, 0, allPaths.Len())
+	path := allPaths.First()
+	for path != nil {
+		sortedPaths = append(sortedPaths, path.Key())
+		path = path.Next()
+	}
+	sort.Strings(sortedPaths)
+
+	for _, pathKey := range sortedPaths {
+		pathItem, ok := allPaths.Get(pathKey)
+		if !ok {
+			continue
+		}
+
+		operations := pathItem.GetOperations()
+		sortedMethods := make([]string, 0, operations.Len())
+		method := operations.First()
+		for method != nil {
+			sortedMethods = append(sortedMethods, method.Key())
+			method = method.Next()
+		}
+		sort.Strings(sortedMethods)
+
+		for _, methodKey := range sortedMethods {
+			operation, ok := operations.Get(methodKey)
+			if !ok {
+				continue
+			}
+
+			// Build route name
+			var routeName string
+			if operation.OperationId != "" {
+				routeName = baseName + "_" + Slugify(operation.OperationId)
+			} else {
+				routeName = baseName + "_" + Slugify(pathKey) + "_" + strings.ToLower(methodKey)
+			}
+
+			route := make(map[string]interface{})
+			if routeDefaults != nil {
+				_ = json.Unmarshal(routeDefaults, &route)
+				delete(route, "service")
+			}
+
+			if !skipID {
+				route["id"] = uuid.NewSHA1(uuidNamespace, []byte(routeName+".route")).String()
+			}
+
+			// Convert path parameters to regex
+			convertedPath := pathKey
+			charsToEscape := []string{"(", ")", ".", "+", "?", "*", "[", "$"}
+			for _, char := range charsToEscape {
+				convertedPath = strings.ReplaceAll(convertedPath, char, "\\"+char)
+			}
+
+			re := regexp.MustCompile(`{([^}]+)}`)
+			regexPriority := 200
+			if matches := re.FindAllStringSubmatch(convertedPath, -1); matches != nil {
+				regexPriority = 100
+				for _, match := range matches {
+					varName := match[1]
+					captureName := strings.ReplaceAll(strings.ToLower(varName), "-", "_")
+					regexMatch := "(?<" + captureName + ">[^#?/]+)"
+					placeHolder := "{" + varName + "}"
+					convertedPath = strings.Replace(convertedPath, placeHolder, regexMatch, 1)
+				}
+			}
+
+			route["name"] = routeName
+			route["paths"] = []string{"~" + convertedPath + "$"}
+			route["methods"] = []string{strings.ToUpper(methodKey)}
+			route["tags"] = tags
+			route["regex_priority"] = regexPriority
+			route["strip_path"] = false
+			route["plugins"] = make([]interface{}, 0)
+
+			routes = append(routes, route)
+		}
+	}
+
+	return routes
+}

--- a/openapi2mcp/openapi2mcp.go
+++ b/openapi2mcp/openapi2mcp.go
@@ -5,16 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/url"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-apiops/logbasics"
-	"github.com/kong/go-slugify"
+	"github.com/kong/go-apiops/openapi2kong"
 	"github.com/pb33f/libopenapi"
 	"github.com/pb33f/libopenapi/datamodel"
 	openapibase "github.com/pb33f/libopenapi/datamodel/high/base"
@@ -24,16 +22,9 @@ import (
 )
 
 const (
-	formatVersionKey   = "_format_version"
-	formatVersionValue = "3.0"
-
 	// MCP proxy modes
 	ModeConversionListener = "conversion-listener"
 	ModeConversion         = "conversion"
-
-	// Default schemes
-	httpScheme  = "http"
-	httpsScheme = "https"
 )
 
 // O2MOptions defines the options for an OpenAPI to MCP conversion operation
@@ -69,27 +60,6 @@ func (opts *O2MOptions) setDefaults() {
 	}
 }
 
-// Slugify converts a name to a valid Kong name by removing and replacing unallowed characters
-// and sanitizing non-latin characters. Multiple inputs will be concatenated using '_'.
-func Slugify(name ...string) string {
-	slugifier := (&slugify.Slugifier{}).ToLower(true).InvalidChar("-").WordSeparator("-")
-	concatBy := "_"
-
-	for i, elem := range name {
-		name[i] = slugifier.Slugify(elem)
-	}
-
-	// drop empty strings from the array
-	for i := 0; i < len(name); i++ {
-		if name[i] == "" {
-			name = append(name[:i], name[i+1:]...)
-			i--
-		}
-	}
-
-	return strings.Join(name, concatBy)
-}
-
 // toKebabCase converts a string to kebab-case
 // Handles camelCase, PascalCase, snake_case, and existing kebab-case
 func toKebabCase(s string) string {
@@ -113,61 +83,6 @@ func toKebabCase(s string) string {
 	s = strings.Trim(s, "-")
 
 	return s
-}
-
-// getKongTags returns the provided tags or if nil, then the `x-kong-tags` property,
-// validated to be a string array.
-func getKongTags(doc v3.Document, tagsProvided []string) ([]string, error) {
-	if tagsProvided != nil {
-		return tagsProvided, nil
-	}
-
-	if doc.Extensions == nil {
-		return make([]string, 0), nil
-	}
-
-	kongTags, ok := doc.Extensions.Get("x-kong-tags")
-	if !ok {
-		return make([]string, 0), nil
-	}
-
-	resultArray := make([]string, len(kongTags.Content))
-	for i, v := range kongTags.Content {
-		var tagsValue interface{}
-		err := yaml.Unmarshal([]byte(v.Value), &tagsValue)
-		if err != nil {
-			return nil, fmt.Errorf("expected 'x-kong-tags' to be an array of strings: %w", err)
-		}
-
-		switch tag := tagsValue.(type) {
-		case string:
-			resultArray[i] = tag
-		default:
-			return nil, fmt.Errorf("expected 'x-kong-tags' to be an array of strings")
-		}
-	}
-
-	return resultArray, nil
-}
-
-// getKongName returns the `x-kong-name` property, validated to be a string
-func getKongName(extensions *orderedmap.Map[string, *yaml.Node]) (string, error) {
-	if extensions == nil {
-		return "", nil
-	}
-
-	xKongName, ok := extensions.Get("x-kong-name")
-	if !ok {
-		return "", nil
-	}
-
-	var name string
-	err := yaml.Unmarshal([]byte(xKongName.Value), &name)
-	if err != nil {
-		return "", fmt.Errorf("expected 'x-kong-name' to be a string: %w", err)
-	}
-
-	return name, nil
 }
 
 // getXKongComponents will return a map of the '/components/x-kong/' object.
@@ -283,28 +198,12 @@ func dereferenceJSONObject(
 	return *result, nil
 }
 
-// getServiceDefaults returns a JSON string containing the service defaults
-func getServiceDefaults(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	components *map[string]interface{},
-) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-service-defaults", components)
-}
-
 // getRouteDefaults returns a JSON string containing the route defaults
 func getRouteDefaults(
 	extensions *orderedmap.Map[string, *yaml.Node],
 	components *map[string]interface{},
 ) ([]byte, error) {
 	return getXKongObject(extensions, "x-kong-route-defaults", components)
-}
-
-// getUpstreamDefaults returns a JSON string containing the upstream defaults
-func getUpstreamDefaults(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	components *map[string]interface{},
-) ([]byte, error) {
-	return getXKongObject(extensions, "x-kong-upstream-defaults", components)
 }
 
 // getMCPProxyConfig returns the x-kong-mcp-proxy override config
@@ -533,255 +432,6 @@ func getExtensionString(extensions *orderedmap.Map[string, *yaml.Node], key stri
 	return value, nil
 }
 
-// getPluginsList returns a list of plugins from x-kong-plugin-* extensions
-func getPluginsList(
-	extensions *orderedmap.Map[string, *yaml.Node],
-	uuidNamespace uuid.UUID,
-	baseName string,
-	components *map[string]interface{},
-	tags []string,
-	skipID bool,
-) ([]*map[string]interface{}, error) {
-	plugins := make(map[string]*map[string]interface{})
-
-	if extensions == nil {
-		return make([]*map[string]interface{}, 0), nil
-	}
-
-	extension := extensions.First()
-	for extension != nil {
-		extensionName := extension.Key()
-		if strings.HasPrefix(extensionName, "x-kong-plugin-") {
-			pluginName := strings.TrimPrefix(extensionName, "x-kong-plugin-")
-
-			jsonstr, err := getXKongObject(extensions, extensionName, components)
-			if err != nil {
-				return nil, err
-			}
-
-			var pluginConfig map[string]interface{}
-			err = json.Unmarshal(jsonstr, &pluginConfig)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse JSON object for '%s': %w", extensionName, err)
-			}
-
-			pluginConfig["name"] = pluginName
-			if !skipID {
-				pluginConfig["id"] = uuid.NewSHA1(uuidNamespace, []byte(baseName+".plugin."+pluginName)).String()
-			}
-			pluginConfig["tags"] = tags
-
-			delete(pluginConfig, "service")
-			delete(pluginConfig, "route")
-
-			plugins[pluginName] = &pluginConfig
-		}
-
-		extension = extension.Next()
-	}
-
-	// Sort plugins by name for deterministic output
-	sortedNames := make([]string, 0, len(plugins))
-	for pluginName := range plugins {
-		sortedNames = append(sortedNames, pluginName)
-	}
-	sort.Strings(sortedNames)
-
-	sorted := make([]*map[string]interface{}, len(plugins))
-	for i, pluginName := range sortedNames {
-		sorted[i] = plugins[pluginName]
-	}
-	return sorted, nil
-}
-
-// parseServerUris parses the server URIs after rendering template variables
-func parseServerUris(servers []*v3.Server) ([]*url.URL, error) {
-	var targets []*url.URL
-
-	if len(servers) == 0 {
-		uriObject, _ := url.ParseRequestURI("/")
-		targets = make([]*url.URL, 1)
-		targets[0] = uriObject
-	} else {
-		targets = make([]*url.URL, len(servers))
-
-		for i, server := range servers {
-			uriString := server.URL
-
-			pair := server.Variables.First()
-			for pair != nil {
-				name := pair.Key()
-				svar := pair.Value()
-				uriString = strings.ReplaceAll(uriString, "{"+name+"}", svar.Default)
-				pair = pair.Next()
-			}
-
-			uriObject, err := url.ParseRequestURI(uriString)
-			if err != nil {
-				return targets, fmt.Errorf("failed to parse uri '%s'; %w", uriString, err)
-			}
-
-			if uriObject.Path == "" {
-				uriObject.Path = "/"
-			}
-
-			targets[i] = uriObject
-		}
-	}
-
-	return targets, nil
-}
-
-// setServerDefaults sets the scheme and port if missing
-func setServerDefaults(targets []*url.URL, schemeDefault string) {
-	for _, target := range targets {
-		if target.Host == "" {
-			target.Host = "localhost"
-		}
-
-		if target.Scheme == "" {
-			switch target.Port() {
-			case "80":
-				target.Scheme = httpScheme
-			case "443":
-				target.Scheme = httpsScheme
-			default:
-				target.Scheme = schemeDefault
-			}
-		}
-
-		if target.Host != "" && target.Port() == "" {
-			if target.Scheme == httpScheme {
-				target.Host = target.Host + ":80"
-			}
-			if target.Scheme == httpsScheme {
-				target.Host = target.Host + ":443"
-			}
-		}
-	}
-}
-
-// createKongUpstream creates a new upstream entity
-func createKongUpstream(
-	baseName string,
-	servers []*v3.Server,
-	upstreamDefaults []byte,
-	tags []string,
-	uuidNamespace uuid.UUID,
-	skipID bool,
-) (map[string]interface{}, error) {
-	var upstream map[string]interface{}
-
-	if upstreamDefaults != nil {
-		_ = json.Unmarshal(upstreamDefaults, &upstream)
-	} else {
-		upstream = make(map[string]interface{})
-	}
-
-	upstreamName := baseName + ".upstream"
-	if !skipID {
-		upstream["id"] = uuid.NewSHA1(uuidNamespace, []byte(upstreamName)).String()
-	}
-	upstream["name"] = upstreamName
-	upstream["tags"] = tags
-
-	targets, err := parseServerUris(servers)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate upstream: %w", err)
-	}
-
-	setServerDefaults(targets, httpsScheme)
-
-	upstreamTargets := make([]map[string]interface{}, len(targets))
-	for i, target := range targets {
-		t := make(map[string]interface{})
-		t["target"] = target.Host
-		t["tags"] = tags
-		upstreamTargets[i] = t
-	}
-	upstream["targets"] = upstreamTargets
-
-	return upstream, nil
-}
-
-// CreateKongService creates a new Kong service entity, and optional upstream
-func CreateKongService(
-	baseName string,
-	servers []*v3.Server,
-	serviceDefaults []byte,
-	upstreamDefaults []byte,
-	tags []string,
-	uuidNamespace uuid.UUID,
-	skipID bool,
-) (map[string]interface{}, map[string]interface{}, error) {
-	var (
-		service  map[string]interface{}
-		upstream map[string]interface{}
-	)
-
-	if serviceDefaults != nil {
-		_ = json.Unmarshal(serviceDefaults, &service)
-	} else {
-		service = make(map[string]interface{})
-	}
-
-	if !skipID {
-		service["id"] = uuid.NewSHA1(uuidNamespace, []byte(baseName+".service")).String()
-	}
-	service["name"] = baseName
-	service["tags"] = tags
-	service["plugins"] = make([]interface{}, 0)
-	service["routes"] = make([]interface{}, 0)
-
-	targets, err := parseServerUris(servers)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create service: %w", err)
-	}
-
-	scheme := httpsScheme
-	if service["protocol"] != nil {
-		scheme = service["protocol"].(string)
-	}
-	setServerDefaults(targets, scheme)
-
-	if service["protocol"] == nil {
-		scheme = targets[0].Scheme
-		service["protocol"] = scheme
-	}
-	if service["path"] == nil {
-		service["path"] = targets[0].Path
-	}
-	if service["port"] == nil {
-		if targets[0].Port() != "" {
-			parsedPort, err := strconv.ParseUint(targets[0].Port(), 10, 16)
-			if err != nil {
-				return nil, nil, err
-			}
-			service["port"] = parsedPort
-		} else {
-			if scheme != httpScheme {
-				service["port"] = 443
-			} else {
-				service["port"] = 80
-			}
-		}
-	}
-
-	if service["host"] == nil {
-		if len(targets) == 1 && upstreamDefaults == nil {
-			service["host"] = targets[0].Hostname()
-		} else {
-			upstream, err = createKongUpstream(baseName, servers, upstreamDefaults, tags, uuidNamespace, skipID)
-			if err != nil {
-				return nil, nil, err
-			}
-			service["host"] = upstream["name"]
-		}
-	}
-
-	return service, upstream, nil
-}
-
 // simplifySchema simplifies an OpenAPI schema to essential properties
 func simplifySchema(schema *openapibase.Schema) map[string]interface{} {
 	if schema == nil {
@@ -986,126 +636,67 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 	opts.setDefaults()
 	logbasics.Debug("received OpenAPI2MCP options", "options", opts)
 
-	// Set up output document
-	result := make(map[string]interface{})
-	result[formatVersionKey] = formatVersionValue
-	services := make([]interface{}, 0)
-	upstreams := make([]interface{}, 0)
+	// convert to openapi2kong options
+	o2kOpts := openapi2kong.O2kOptions{
+		Tags:          opts.Tags,
+		DocName:       opts.DocName,
+		UUIDNamespace: opts.UUIDNamespace,
+		SkipID:        opts.SkipID,
+	}
 
-	var (
-		err            error
-		doc            v3.Document
-		kongComponents *map[string]interface{}
-		kongTags       []string
+	// generate the base Kong configuration
+	result, err := openapi2kong.Convert(content, o2kOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate base Kong configuration: %w", err)
+	}
 
-		docBaseName         string
-		docServers          []*v3.Server
-		docServiceDefaults  []byte
-		docUpstreamDefaults []byte
-		docRouteDefaults    []byte
-		docService          map[string]interface{}
-		docUpstream         map[string]interface{}
-	)
-
-	// Load and parse the OAS file
+	// Load and parse the OAS file to get the v3 model
 	openapiDoc, err := libopenapi.NewDocument(content)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing OAS3 file: [%w]", err)
 	}
-
-	// Configure document options
 	docConfig := datamodel.NewDocumentConfiguration()
 	docConfig.IgnoreArrayCircularReferences = true
 	docConfig.IgnorePolymorphicCircularReferences = true
 	openapiDoc.SetConfiguration(docConfig)
-
 	v3Model, errs := openapiDoc.BuildV3Model()
 	if errs != nil {
 		logbasics.Error(errs, "error while building v3 document model")
 		return nil, fmt.Errorf("cannot create v3 model from document: %w", errs)
 	}
-
+	var doc v3.Document
 	if v3Model != nil {
 		doc = v3Model.Model
 	}
 
-	// Collect tags
-	if kongTags, err = getKongTags(doc, opts.Tags); err != nil {
-		return nil, err
+	// get the main service
+	services, ok := result["services"].([]interface{})
+	if !ok || len(services) == 0 {
+		return nil, fmt.Errorf("no services generated")
 	}
+	docService, ok := services[0].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("generated service is not a valid object")
+	}
+	docBaseName := docService["name"].(string)
 
-	// Set document level elements
-	docServers = doc.Servers
+	// handle routes
+	if !opts.IncludeDirectRoute {
+		docService["routes"] = make([]interface{}, 0)
+	}
+	routes := docService["routes"].([]interface{})
 
-	// Determine document name
-	docBaseName = opts.DocName
-	if docBaseName == "" {
-		if docBaseName, err = getKongName(doc.Extensions); err != nil {
-			return nil, err
-		}
-		if docBaseName == "" {
-			if doc.Info != nil && doc.Info.Title != "" {
-				docBaseName = doc.Info.Title
-			} else {
-				id, err := uuid.NewRandom()
-				if err != nil {
-					return nil, fmt.Errorf("failed to generate UUID: %w", err)
-				}
-				docBaseName = id.String()
-			}
-		}
-	}
-	docBaseName = Slugify(docBaseName)
-
-	if kongComponents, err = getXKongComponents(doc); err != nil {
-		return nil, err
-	}
-
-	// Get defaults
-	if docServiceDefaults, err = getServiceDefaults(doc.Extensions, kongComponents); err != nil {
-		return nil, err
-	}
-	if docUpstreamDefaults, err = getUpstreamDefaults(doc.Extensions, kongComponents); err != nil {
-		return nil, err
-	}
-	if docRouteDefaults, err = getRouteDefaults(doc.Extensions, kongComponents); err != nil {
-		return nil, err
-	}
-
-	// Create the Kong service and optional upstream
-	docService, docUpstream, err = CreateKongService(
-		docBaseName,
-		docServers,
-		docServiceDefaults,
-		docUpstreamDefaults,
-		kongTags,
-		opts.UUIDNamespace,
-		opts.SkipID,
-	)
+	// get kong components and defaults
+	kongComponents, err := getXKongComponents(doc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create service/upstream: %w", err)
+		return nil, err
 	}
-
-	services = append(services, docService)
-	if docUpstream != nil {
-		upstreams = append(upstreams, docUpstream)
-	}
-
-	// Get document-level plugins
-	docPlugins, err := getPluginsList(
-		doc.Extensions, opts.UUIDNamespace, docBaseName, kongComponents, kongTags, opts.SkipID)
+	docRouteDefaults, err := getRouteDefaults(doc.Extensions, kongComponents)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get plugins list: %w", err)
-	}
-	docService["plugins"] = docPlugins
-
-	// Check for paths
-	if doc.Paths == nil {
-		return nil, fmt.Errorf("must have `.paths` in the root of the document")
+		return nil, err
 	}
 
 	// Detect ACL security configuration
-	// If any oauth2 security scheme has x-kong-mcp-acl, we'll generate ACL entries
 	_, aclConfig, err := findACLSecurityScheme(doc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read security scheme ACL config: %w", err)
@@ -1122,62 +713,59 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 
 	// Build MCP tools from all operations
 	tools := make([]interface{}, 0)
-
-	// Create sorted array of paths for deterministic output
-	allPaths := doc.Paths.PathItems
-	sortedPaths := make([]string, 0, allPaths.Len())
-	path := allPaths.First()
-	for path != nil {
-		sortedPaths = append(sortedPaths, path.Key())
-		path = path.Next()
-	}
-	sort.Strings(sortedPaths)
-
-	for _, pathKey := range sortedPaths {
-		pathItem, ok := allPaths.Get(pathKey)
-		if !ok {
-			continue
+	if doc.Paths != nil {
+		allPaths := doc.Paths.PathItems
+		sortedPaths := make([]string, 0, allPaths.Len())
+		path := allPaths.First()
+		for path != nil {
+			sortedPaths = append(sortedPaths, path.Key())
+			path = path.Next()
 		}
+		sort.Strings(sortedPaths)
 
-		operations := pathItem.GetOperations()
-		sortedMethods := make([]string, 0, operations.Len())
-		method := operations.First()
-		for method != nil {
-			sortedMethods = append(sortedMethods, method.Key())
-			method = method.Next()
-		}
-		sort.Strings(sortedMethods)
-
-		for _, methodKey := range sortedMethods {
-			operation, ok := operations.Get(methodKey)
+		for _, pathKey := range sortedPaths {
+			pathItem, ok := allPaths.Get(pathKey)
 			if !ok {
 				continue
 			}
 
-			// Check if operation is excluded
-			excluded, err := getExtensionBool(operation.Extensions, "x-kong-mcp-exclude")
-			if err != nil {
-				return nil, err
+			operations := pathItem.GetOperations()
+			sortedMethods := make([]string, 0, operations.Len())
+			method := operations.First()
+			for method != nil {
+				sortedMethods = append(sortedMethods, method.Key())
+				method = method.Next()
 			}
-			if excluded {
-				continue
-			}
+			sort.Strings(sortedMethods)
 
-			// Get per-tool ACL from security requirements
-			var toolACL map[string]interface{}
-			if aclConfig != nil {
-				toolACL, err = getOperationACL(operation.Security, doc.Security, doc, opts.IgnoreSecurityErrors)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get ACL for %s %s: %w", methodKey, pathKey, err)
+			for _, methodKey := range sortedMethods {
+				operation, ok := operations.Get(methodKey)
+				if !ok {
+					continue
 				}
-			}
 
-			tool, err := buildMCPTool(pathKey, methodKey, operation, pathItem.Parameters, toolACL)
-			if err != nil {
-				return nil, fmt.Errorf("failed to build MCP tool for %s %s: %w", methodKey, pathKey, err)
-			}
+				excluded, err := getExtensionBool(operation.Extensions, "x-kong-mcp-exclude")
+				if err != nil {
+					return nil, err
+				}
+				if excluded {
+					continue
+				}
 
-			tools = append(tools, tool)
+				var toolACL map[string]interface{}
+				if aclConfig != nil {
+					toolACL, err = getOperationACL(operation.Security, doc.Security, doc, opts.IgnoreSecurityErrors)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get ACL for %s %s: %w", methodKey, pathKey, err)
+					}
+				}
+
+				tool, err := buildMCPTool(pathKey, methodKey, operation, pathItem.Parameters, toolACL)
+				if err != nil {
+					return nil, fmt.Errorf("failed to build MCP tool for %s %s: %w", methodKey, pathKey, err)
+				}
+				tools = append(tools, tool)
+			}
 		}
 	}
 
@@ -1199,7 +787,7 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 	}
 	mcpRoute["name"] = mcpRouteName
 	mcpRoute["paths"] = []string{mcpRoutePath}
-	mcpRoute["tags"] = kongTags
+	mcpRoute["tags"] = docService["tags"]
 
 	// Build ai-mcp-proxy plugin config
 	mcpPluginConfig := map[string]interface{}{
@@ -1207,7 +795,6 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 		"tools": tools,
 	}
 
-	// Add ACL configuration to plugin config if security was detected
 	if aclConfig != nil {
 		if v, ok := aclConfig["acl_attribute_type"]; ok {
 			mcpPluginConfig["acl_attribute_type"] = v
@@ -1220,7 +807,6 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 		mcpPluginConfig["default_acl"] = defaultACL
 	}
 
-	// Check for x-kong-mcp-proxy override
 	mcpProxyOverride, err := getMCPProxyConfig(doc.Extensions, kongComponents)
 	if err != nil {
 		return nil, err
@@ -1228,9 +814,8 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 	if mcpProxyOverride != nil {
 		var override map[string]interface{}
 		_ = json.Unmarshal(mcpProxyOverride, &override)
-		// Merge override into config (override takes precedence except for tools)
 		for k, v := range override {
-			if k != "tools" { // Don't override generated tools
+			if k != "tools" {
 				mcpPluginConfig[k] = v
 			}
 		}
@@ -1244,125 +829,19 @@ func Convert(content []byte, opts O2MOptions) (map[string]interface{}, error) {
 	if !opts.SkipID {
 		mcpPlugin["id"] = uuid.NewSHA1(opts.UUIDNamespace, []byte(mcpRouteName+".plugin.ai-mcp-proxy")).String()
 	}
-	mcpPlugin["tags"] = kongTags
+	mcpPlugin["tags"] = docService["tags"]
 
 	mcpRoute["plugins"] = []interface{}{mcpPlugin}
 
 	// Add MCP route to service
-	routes := docService["routes"].([]interface{})
-	routes = append(routes, mcpRoute)
-
-	// Optionally add direct routes (non-MCP)
-	if opts.IncludeDirectRoute {
-		directRoutes := buildDirectRoutes(doc, docBaseName, docRouteDefaults, kongTags, opts.UUIDNamespace, opts.SkipID)
-		routes = append(routes, directRoutes...)
-	}
-
+	routes = append([]interface{}{mcpRoute}, routes...)
 	docService["routes"] = routes
 
-	// Build result
-	result["services"] = services
-	if len(upstreams) > 0 {
-		result["upstreams"] = upstreams
+	if upstreams, ok := result["upstreams"].([]interface{}); ok {
+		if len(upstreams) == 0 {
+			delete(result, "upstreams")
+		}
 	}
 
 	return result, nil
-}
-
-// buildDirectRoutes builds traditional Kong routes for direct API access (non-MCP)
-func buildDirectRoutes(
-	doc v3.Document,
-	baseName string,
-	routeDefaults []byte,
-	tags []string,
-	uuidNamespace uuid.UUID,
-	skipID bool,
-) []interface{} {
-	routes := make([]interface{}, 0)
-
-	if doc.Paths == nil {
-		return routes
-	}
-
-	allPaths := doc.Paths.PathItems
-	sortedPaths := make([]string, 0, allPaths.Len())
-	path := allPaths.First()
-	for path != nil {
-		sortedPaths = append(sortedPaths, path.Key())
-		path = path.Next()
-	}
-	sort.Strings(sortedPaths)
-
-	for _, pathKey := range sortedPaths {
-		pathItem, ok := allPaths.Get(pathKey)
-		if !ok {
-			continue
-		}
-
-		operations := pathItem.GetOperations()
-		sortedMethods := make([]string, 0, operations.Len())
-		method := operations.First()
-		for method != nil {
-			sortedMethods = append(sortedMethods, method.Key())
-			method = method.Next()
-		}
-		sort.Strings(sortedMethods)
-
-		for _, methodKey := range sortedMethods {
-			operation, ok := operations.Get(methodKey)
-			if !ok {
-				continue
-			}
-
-			// Build route name
-			var routeName string
-			if operation.OperationId != "" {
-				routeName = baseName + "_" + Slugify(operation.OperationId)
-			} else {
-				routeName = baseName + "_" + Slugify(pathKey) + "_" + strings.ToLower(methodKey)
-			}
-
-			route := make(map[string]interface{})
-			if routeDefaults != nil {
-				_ = json.Unmarshal(routeDefaults, &route)
-				delete(route, "service")
-			}
-
-			if !skipID {
-				route["id"] = uuid.NewSHA1(uuidNamespace, []byte(routeName+".route")).String()
-			}
-
-			// Convert path parameters to regex
-			convertedPath := pathKey
-			charsToEscape := []string{"(", ")", ".", "+", "?", "*", "[", "$"}
-			for _, char := range charsToEscape {
-				convertedPath = strings.ReplaceAll(convertedPath, char, "\\"+char)
-			}
-
-			re := regexp.MustCompile(`{([^}]+)}`)
-			regexPriority := 200
-			if matches := re.FindAllStringSubmatch(convertedPath, -1); matches != nil {
-				regexPriority = 100
-				for _, match := range matches {
-					varName := match[1]
-					captureName := strings.ReplaceAll(strings.ToLower(varName), "-", "_")
-					regexMatch := "(?<" + captureName + ">[^#?/]+)"
-					placeHolder := "{" + varName + "}"
-					convertedPath = strings.Replace(convertedPath, placeHolder, regexMatch, 1)
-				}
-			}
-
-			route["name"] = routeName
-			route["paths"] = []string{"~" + convertedPath + "$"}
-			route["methods"] = []string{strings.ToUpper(methodKey)}
-			route["tags"] = tags
-			route["regex_priority"] = regexPriority
-			route["strip_path"] = false
-			route["plugins"] = make([]interface{}, 0)
-
-			routes = append(routes, route)
-		}
-	}
-
-	return routes
 }

--- a/openapi2mcp/openapi2mcp_suite_test.go
+++ b/openapi2mcp/openapi2mcp_suite_test.go
@@ -1,0 +1,13 @@
+package openapi2mcp
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestOpenapi2mcp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Openapi2mcp Suite")
+}

--- a/openapi2mcp/openapi2mcp_test.go
+++ b/openapi2mcp/openapi2mcp_test.go
@@ -301,6 +301,7 @@ paths:
       parameters:
         - name: date
           in: query
+          required: false
           schema:
             type: string
             format: date

--- a/openapi2mcp/openapi2mcp_test.go
+++ b/openapi2mcp/openapi2mcp_test.go
@@ -2,7 +2,6 @@ package openapi2mcp
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -261,28 +260,6 @@ paths:
 	plugins := route["plugins"].([]interface{})
 	plugin := plugins[0].(map[string]interface{})
 	assert.Nil(t, plugin["id"], "plugin should not have id when SkipID=true")
-}
-
-func Test_Openapi2mcp_ToolNameNormalization(t *testing.T) {
-	// Test tool name kebab-case normalization
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		{"getFlights", "get-flights"},
-		{"get_flights", "get-flights"},
-		{"GetFlights", "get-flights"},
-		{"get-flights", "get-flights"},
-		{"listAllUsers", "list-all-users"},
-		{"CreateNewItem", "create-new-item"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.input, func(t *testing.T) {
-			result := toKebabCase(tc.input)
-			assert.Equal(t, tc.expected, result, fmt.Sprintf("toKebabCase(%s)", tc.input))
-		})
-	}
 }
 
 func Test_Openapi2mcp_SimplifySchema(t *testing.T) {

--- a/openapi2mcp/openapi2mcp_test.go
+++ b/openapi2mcp/openapi2mcp_test.go
@@ -1,0 +1,693 @@
+package openapi2mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const fixturePath = "./oas3_testfiles/"
+
+// findFilesBySuffix returns a list of files in the fixturePath
+// that end with the given suffix.
+func findFilesBySuffix(t *testing.T, dir string, suffix string) []fs.DirEntry {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Error("failed reading test data: %w", err)
+	}
+
+	// loop over all files, and remove anything that doesn't end with the suffix
+	for i := 0; i < len(files); i++ {
+		if !strings.HasSuffix(files[i].Name(), suffix) {
+			files = slices.Delete(files, i, i+1)
+			i--
+		}
+	}
+
+	return files
+}
+
+func Test_Openapi2mcp_InvalidPaths(t *testing.T) {
+	dir := filepath.Join(fixturePath, "invalid")
+	files := findFilesBySuffix(t, dir, ".yaml")
+
+	// Define expected error messages for different test files
+	expectedErrors := map[string]string{
+		"no-paths.yaml": "must have `.paths` in the root of the document",
+	}
+
+	for _, file := range files {
+		fileNameIn := file.Name()
+		t.Run(fileNameIn, func(t *testing.T) {
+			dataIn, _ := os.ReadFile(filepath.Join(dir, fileNameIn))
+			_, err := Convert(dataIn, O2MOptions{
+				Tags: []string{"OAS3_import", "OAS3file_" + fileNameIn},
+			})
+
+			if err == nil {
+				t.Errorf("'%s' expected error but got none", fileNameIn)
+			} else {
+				expectedError, exists := expectedErrors[fileNameIn]
+				if !exists {
+					t.Errorf("No expected error defined for test file: %s", fileNameIn)
+				} else {
+					assert.Contains(t, err.Error(), expectedError,
+						"Error message for '%s' should contain '%s', but got: %s",
+						fileNameIn, expectedError, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func Test_Openapi2mcp_Basic(t *testing.T) {
+	// Test basic conversion with default options
+	files := []string{
+		"01-basic-conversion.yaml",
+		"02-mcp-extensions.yaml",
+		"07-multiple-servers.yaml",
+	}
+
+	for _, fileNameIn := range files {
+		t.Run(fileNameIn, func(t *testing.T) {
+			fileNameExpected := strings.TrimSuffix(fileNameIn, ".yaml") + ".expected.json"
+			fileNameOut := strings.TrimSuffix(fileNameIn, ".yaml") + ".generated.json"
+			dataIn, err := os.ReadFile(fixturePath + fileNameIn)
+			if err != nil {
+				t.Fatalf("Failed to read input file: %v", err)
+			}
+
+			dataOut, err := Convert(dataIn, O2MOptions{
+				Tags: []string{"OAS3_import", "OAS3file_" + fileNameIn},
+			})
+			if err != nil {
+				t.Errorf("'%s' didn't expect error: %v", fixturePath+fileNameIn, err)
+				return
+			}
+
+			JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+			os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+			JSONExpected, err := os.ReadFile(fixturePath + fileNameExpected)
+			if err != nil {
+				t.Fatalf("Failed to read expected file: %v", err)
+			}
+
+			assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+				"'%s': the JSON blobs should be equal", fixturePath+fileNameIn)
+		})
+	}
+}
+
+func Test_Openapi2mcp_ConversionMode(t *testing.T) {
+	// Test with mode=conversion
+	fileNameIn := "03-mode-conversion.yaml"
+	fileNameExpected := "03-mode-conversion.expected.json"
+	fileNameOut := "03-mode-conversion.generated.json"
+
+	dataIn, err := os.ReadFile(fixturePath + fileNameIn)
+	if err != nil {
+		t.Fatalf("Failed to read input file: %v", err)
+	}
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		Tags: []string{"OAS3_import", "OAS3file_" + fileNameIn},
+		Mode: ModeConversion,
+	})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+	os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+	JSONExpected, err := os.ReadFile(fixturePath + fileNameExpected)
+	if err != nil {
+		t.Fatalf("Failed to read expected file: %v", err)
+	}
+
+	assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+		"the JSON blobs should be equal for mode=conversion")
+}
+
+func Test_Openapi2mcp_DirectRoute(t *testing.T) {
+	// Test with IncludeDirectRoute=true
+	fileNameIn := "04-direct-route.yaml"
+	fileNameExpected := "04-direct-route.expected.json"
+	fileNameOut := "04-direct-route.generated.json"
+
+	dataIn, err := os.ReadFile(fixturePath + fileNameIn)
+	if err != nil {
+		t.Fatalf("Failed to read input file: %v", err)
+	}
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		Tags:               []string{"OAS3_import", "OAS3file_" + fileNameIn},
+		IncludeDirectRoute: true,
+	})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+	os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+	JSONExpected, err := os.ReadFile(fixturePath + fileNameExpected)
+	if err != nil {
+		t.Fatalf("Failed to read expected file: %v", err)
+	}
+
+	assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+		"the JSON blobs should be equal for IncludeDirectRoute=true")
+}
+
+func Test_Openapi2mcp_KongExtensions(t *testing.T) {
+	// Test with Kong extensions
+	fileNameIn := "05-kong-extensions.yaml"
+	fileNameExpected := "05-kong-extensions.expected.json"
+	fileNameOut := "05-kong-extensions.generated.json"
+
+	dataIn, err := os.ReadFile(fixturePath + fileNameIn)
+	if err != nil {
+		t.Fatalf("Failed to read input file: %v", err)
+	}
+
+	dataOut, err := Convert(dataIn, O2MOptions{})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+	os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+	JSONExpected, err := os.ReadFile(fixturePath + fileNameExpected)
+	if err != nil {
+		t.Fatalf("Failed to read expected file: %v", err)
+	}
+
+	assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+		"the JSON blobs should be equal for Kong extensions")
+}
+
+func Test_Openapi2mcp_CustomPathPrefix(t *testing.T) {
+	// Test with custom path prefix
+	fileNameIn := "06-custom-path-prefix.yaml"
+	fileNameExpected := "06-custom-path-prefix.expected.json"
+	fileNameOut := "06-custom-path-prefix.generated.json"
+
+	dataIn, err := os.ReadFile(fixturePath + fileNameIn)
+	if err != nil {
+		t.Fatalf("Failed to read input file: %v", err)
+	}
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		Tags:       []string{"OAS3_import", "OAS3file_" + fileNameIn},
+		PathPrefix: "/custom/mcp/path",
+	})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+	os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+	JSONExpected, err := os.ReadFile(fixturePath + fileNameExpected)
+	if err != nil {
+		t.Fatalf("Failed to read expected file: %v", err)
+	}
+
+	assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+		"the JSON blobs should be equal for custom path prefix")
+}
+
+func Test_Openapi2mcp_NoID(t *testing.T) {
+	// Test with SkipID=true
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List items
+`)
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	// Verify no id fields are present
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	assert.Nil(t, service["id"], "service should not have id when SkipID=true")
+
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	assert.Nil(t, route["id"], "route should not have id when SkipID=true")
+
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	assert.Nil(t, plugin["id"], "plugin should not have id when SkipID=true")
+}
+
+func Test_Openapi2mcp_ToolNameNormalization(t *testing.T) {
+	// Test tool name kebab-case normalization
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"getFlights", "get-flights"},
+		{"get_flights", "get-flights"},
+		{"GetFlights", "get-flights"},
+		{"get-flights", "get-flights"},
+		{"listAllUsers", "list-all-users"},
+		{"CreateNewItem", "create-new-item"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := toKebabCase(tc.input)
+			assert.Equal(t, tc.expected, result, fmt.Sprintf("toKebabCase(%s)", tc.input))
+		})
+	}
+}
+
+func Test_Openapi2mcp_SimplifySchema(t *testing.T) {
+	// Test that schemas are simplified properly
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List items
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date
+            pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+            minLength: 10
+            maxLength: 10
+`)
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	// Navigate to the parameter schema
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+	tools := config["tools"].([]interface{})
+	tool := tools[0].(map[string]interface{})
+	params := tool["parameters"].([]map[string]interface{})
+	param := params[0]
+	schema := param["schema"].(map[string]interface{})
+
+	// Verify schema is simplified - only type should be present
+	assert.Equal(t, "string", schema["type"], "schema should have type")
+	assert.Nil(t, schema["format"], "schema should not have format (simplified)")
+	assert.Nil(t, schema["pattern"], "schema should not have pattern (simplified)")
+	assert.Nil(t, schema["minLength"], "schema should not have minLength (simplified)")
+	assert.Nil(t, schema["maxLength"], "schema should not have maxLength (simplified)")
+}
+
+func Test_Openapi2mcp_SecurityACL(t *testing.T) {
+	// Test ACL generation from oauth2 security with x-kong-mcp-acl
+	fileNameIn := "08-security-acl.yaml"
+	fileNameExpected := "08-security-acl.expected.json"
+	fileNameOut := "08-security-acl.generated.json"
+
+	dataIn, err := os.ReadFile(fixturePath + fileNameIn)
+	if err != nil {
+		t.Fatalf("Failed to read input file: %v", err)
+	}
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		Tags: []string{"OAS3_import", "OAS3file_" + fileNameIn},
+	})
+	if err != nil {
+		t.Errorf("didn't expect error: %v", err)
+		return
+	}
+
+	JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+	os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+	JSONExpected, err := os.ReadFile(fixturePath + fileNameExpected)
+	if err != nil {
+		t.Fatalf("Failed to read expected file: %v", err)
+	}
+
+	assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+		"the JSON blobs should be equal for security ACL")
+
+	// Also verify the ACL structure programmatically
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+
+	// Verify plugin-level ACL config
+	assert.Equal(t, "oauth_access_token", config["acl_attribute_type"],
+		"acl_attribute_type should be set")
+	assert.Equal(t, "scp", config["access_token_claim_field"],
+		"access_token_claim_field should be set")
+	assert.NotNil(t, config["default_acl"], "default_acl should be set")
+
+	// Verify per-tool ACL
+	tools := config["tools"].([]interface{})
+	assert.Len(t, tools, 3, "should have 3 tools (excluded operation filtered)")
+
+	// First tool: get-cool-flights with flights:read
+	tool0 := tools[0].(map[string]interface{})
+	assert.Equal(t, "get-cool-flights", tool0["name"])
+	acl0 := tool0["acl"].(map[string]interface{})
+	assert.Equal(t, []string{"flights:read"}, acl0["allow"])
+
+	// Second tool: create-flight with flights:write
+	tool1 := tools[1].(map[string]interface{})
+	assert.Equal(t, "create-flight", tool1["name"])
+	acl1 := tool1["acl"].(map[string]interface{})
+	assert.Equal(t, []string{"flights:write"}, acl1["allow"])
+
+	// Third tool: get-flight-by-number with flights:read
+	tool2 := tools[2].(map[string]interface{})
+	assert.Equal(t, "get-flight-by-number", tool2["name"])
+	acl2 := tool2["acl"].(map[string]interface{})
+	assert.Equal(t, []string{"flights:read"}, acl2["allow"])
+}
+
+func Test_Openapi2mcp_SecurityACL_NoExtension(t *testing.T) {
+	// Test that oauth2 security without x-kong-mcp-acl doesn't generate ACL (auto-detect)
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      security:
+        - my_oauth:
+            - items:read
+      operationId: list-items
+      summary: List items
+components:
+  securitySchemes:
+    my_oauth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            items:read: Read items
+`)
+
+	// Without x-kong-mcp-acl on the scheme, ACL generation is not activated (auto-detect).
+	// No error should occur, and no ACL fields should be generated.
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	assert.NoError(t, err, "should not error when oauth2 scheme lacks x-kong-mcp-acl (auto-detect)")
+
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+
+	// Should have no ACL fields
+	assert.Nil(t, config["acl_attribute_type"], "should not have acl_attribute_type")
+	assert.Nil(t, config["access_token_claim_field"], "should not have access_token_claim_field")
+
+	// Tool should have no ACL
+	tools := config["tools"].([]interface{})
+	tool := tools[0].(map[string]interface{})
+	assert.Nil(t, tool["acl"], "tool should not have acl")
+}
+
+func Test_Openapi2mcp_SecurityACL_UnsupportedScheme(t *testing.T) {
+	// Test that non-oauth2 security scheme is silently skipped (no x-kong-mcp-acl to activate ACL)
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      security:
+        - api_key: []
+      operationId: list-items
+      summary: List items
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      in: header
+      name: X-API-Key
+`)
+
+	// Without any scheme having x-kong-mcp-acl, ACL is not activated, so no error
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	assert.NoError(t, err, "should not error for non-oauth2 scheme without ACL activation")
+
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+
+	tools := config["tools"].([]interface{})
+	tool := tools[0].(map[string]interface{})
+	assert.Nil(t, tool["acl"], "tool should not have acl for non-oauth2 scheme")
+}
+
+func Test_Openapi2mcp_SecurityACL_MixedSchemes(t *testing.T) {
+	// Test that when an oauth2 scheme has x-kong-mcp-acl but an operation references
+	// a different non-oauth2 scheme, it errors (unless ignore-security-errors is set)
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      security:
+        - api_key: []
+      operationId: list-items
+      summary: List items
+  /users:
+    get:
+      security:
+        - my_oauth:
+            - users:read
+      operationId: list-users
+      summary: List users
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      in: header
+      name: X-API-Key
+    my_oauth:
+      type: oauth2
+      x-kong-mcp-acl:
+        acl_attribute_type: oauth_access_token
+        access_token_claim_field: scp
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            users:read: Read users
+`)
+
+	// The api_key operation should error because ACL is activated (my_oauth has x-kong-mcp-acl)
+	// but api_key is not oauth2
+	_, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	assert.Error(t, err, "should error when operation uses non-oauth2 scheme while ACL is active")
+	assert.Contains(t, err.Error(), "oauth2")
+
+	// With ignore-security-errors, api_key operation should have no ACL, oauth operation should
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID:               true,
+		IgnoreSecurityErrors: true,
+	})
+	assert.NoError(t, err, "should not error with ignore-security-errors")
+
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+
+	tools := config["tools"].([]interface{})
+	assert.Len(t, tools, 2)
+
+	// First tool (list-items with api_key) should have no ACL
+	tool0 := tools[0].(map[string]interface{})
+	assert.Equal(t, "list-items", tool0["name"])
+	assert.Nil(t, tool0["acl"], "api_key tool should not have acl")
+
+	// Second tool (list-users with my_oauth) should have ACL
+	tool1 := tools[1].(map[string]interface{})
+	assert.Equal(t, "list-users", tool1["name"])
+	acl1 := tool1["acl"].(map[string]interface{})
+	assert.Equal(t, []string{"users:read"}, acl1["allow"])
+}
+
+func Test_Openapi2mcp_SecurityACL_NoSecurity(t *testing.T) {
+	// Test that specs without any security don't generate ACL
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List items
+`)
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	assert.NoError(t, err, "should not error without security")
+
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+
+	assert.Nil(t, config["acl_attribute_type"], "should not have acl_attribute_type")
+	assert.Nil(t, config["access_token_claim_field"], "should not have access_token_claim_field")
+	assert.Nil(t, config["default_acl"], "should not have default_acl")
+
+	tools := config["tools"].([]interface{})
+	tool := tools[0].(map[string]interface{})
+	assert.Nil(t, tool["acl"], "tool should not have acl")
+}
+
+func Test_Openapi2mcp_SecurityACL_DocLevelInheritance(t *testing.T) {
+	// Test that operations without security inherit from document-level security
+	dataIn := []byte(`
+openapi: 3.0.0
+info:
+  title: Test API
+servers:
+  - url: https://api.example.com
+security:
+  - my_oauth:
+      - items:read
+paths:
+  /items:
+    get:
+      operationId: list-items
+      summary: List items
+  /items/{id}:
+    get:
+      operationId: get-item
+      summary: Get item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+components:
+  securitySchemes:
+    my_oauth:
+      type: oauth2
+      x-kong-mcp-acl:
+        acl_attribute_type: oauth_access_token
+        access_token_claim_field: scp
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            items:read: Read items
+`)
+
+	dataOut, err := Convert(dataIn, O2MOptions{
+		SkipID: true,
+	})
+	assert.NoError(t, err, "should not error")
+
+	services := dataOut["services"].([]interface{})
+	service := services[0].(map[string]interface{})
+	routes := service["routes"].([]interface{})
+	route := routes[0].(map[string]interface{})
+	plugins := route["plugins"].([]interface{})
+	plugin := plugins[0].(map[string]interface{})
+	config := plugin["config"].(map[string]interface{})
+
+	// Verify plugin-level ACL config
+	assert.Equal(t, "oauth_access_token", config["acl_attribute_type"])
+	assert.Equal(t, "scp", config["access_token_claim_field"])
+
+	// Both tools should inherit ACL from document level
+	tools := config["tools"].([]interface{})
+	assert.Len(t, tools, 2)
+
+	tool0 := tools[0].(map[string]interface{})
+	acl0 := tool0["acl"].(map[string]interface{})
+	assert.Equal(t, []string{"items:read"}, acl0["allow"],
+		"first tool should inherit doc-level security scopes")
+
+	tool1 := tools[1].(map[string]interface{})
+	acl1 := tool1["acl"].(map[string]interface{})
+	assert.Equal(t, []string{"items:read"}, acl1["allow"],
+		"second tool should inherit doc-level security scopes")
+}

--- a/openapi2mcp/openapi2mcp_test.go
+++ b/openapi2mcp/openapi2mcp_test.go
@@ -301,7 +301,6 @@ paths:
       parameters:
         - name: date
           in: query
-          required: false
           schema:
             type: string
             format: date

--- a/openapitools/service.go
+++ b/openapitools/service.go
@@ -1,4 +1,4 @@
-package openapi2kong
+package openapitools
 
 import (
 	"encoding/json"

--- a/openapitools/service_test.go
+++ b/openapitools/service_test.go
@@ -1,4 +1,4 @@
-package openapi2kong
+package openapitools
 
 import (
 	"net/url"

--- a/openapitools/utils.go
+++ b/openapitools/utils.go
@@ -1,4 +1,4 @@
-package openapi2kong
+package openapitools
 
 import (
 	"fmt"
@@ -39,10 +39,10 @@ func Slugify(insoCompat bool, name ...string) string {
 	return strings.Join(name, concatBy)
 }
 
-// sanitizeRegexCapture will remove illegal characters from the path-variable name.
+// SanitizeRegexCapture will remove illegal characters from the path-variable name.
 // The returned name will be valid for PCRE regex captures; Alphanumeric + '_', starting
 // with [a-zA-Z].
-func sanitizeRegexCapture(varName string, insoCompat bool) string {
+func SanitizeRegexCapture(varName string, insoCompat bool) string {
 	var regexName *slugify.Slugifier
 	if insoCompat {
 		regexName = (&slugify.Slugifier{}).ToLower(false).InvalidChar("_").WordSeparator("_")
@@ -52,7 +52,8 @@ func sanitizeRegexCapture(varName string, insoCompat bool) string {
 	return regexName.Slugify(varName)
 }
 
-func dereferenceJSONObject(
+// DereferenceJSONObject will dereference a JSON object.
+func DereferenceJSONObject(
 	value map[string]interface{},
 	components *map[string]interface{},
 ) (map[string]interface{}, error) {
@@ -95,7 +96,8 @@ func dereferenceJSONObject(
 	return *result, nil
 }
 
-func convertYamlNodeToBytes(node *yaml.Node) ([]byte, error) {
+// ConvertYamlNodeToBytes will convert a yaml node to bytes.
+func ConvertYamlNodeToBytes(node *yaml.Node) ([]byte, error) {
 	var data interface{}
 	err := node.Decode(&data)
 	if err != nil {
@@ -104,9 +106,9 @@ func convertYamlNodeToBytes(node *yaml.Node) ([]byte, error) {
 	return yaml.Marshal(data)
 }
 
-// crossProduct computes the Cartesian product of the input slices.
+// CrossProduct computes the Cartesian product of the input slices.
 // The slices can be of any type
-func crossProduct(slices ...[]any) [][]any {
+func CrossProduct(slices ...[]any) [][]any {
 	if len(slices) == 0 {
 		return [][]any{{}}
 	}

--- a/openapitools/utils.go
+++ b/openapitools/utils.go
@@ -1,12 +1,42 @@
 package openapitools
 
 import (
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
+	"github.com/kong/go-apiops/jsonbasics"
 	"github.com/kong/go-slugify"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
 	"go.yaml.in/yaml/v4"
 )
+
+// ToKebabCase converts a string to kebab-case
+// Handles camelCase, PascalCase, snake_case, and existing kebab-case
+func ToKebabCase(s string) string {
+	// First, replace underscores and spaces with hyphens
+	s = strings.ReplaceAll(s, "_", "-")
+	s = strings.ReplaceAll(s, " ", "-")
+
+	// Insert hyphens before uppercase letters (for camelCase/PascalCase)
+	re := regexp.MustCompile(`([a-z0-9])([A-Z])`)
+	s = re.ReplaceAllString(s, "${1}-${2}")
+
+	// Convert to lowercase
+	s = strings.ToLower(s)
+
+	// Remove any double hyphens
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+
+	// Trim leading/trailing hyphens
+	s = strings.Trim(s, "-")
+
+	return s
+}
 
 // Slugify converts a name to a valid Kong name by removing and replacing unallowed characters
 // and sanitizing non-latin characters. Multiple inputs will be concatenated using '_'.
@@ -127,4 +157,78 @@ func CrossProduct(slices ...[]any) [][]any {
 	}
 
 	return result
+}
+
+// GetXKongComponents returns a map of the '/components/x-kong/' object. If
+// the extension is not there it will return an empty map. If the entry is not a
+// yaml object, it will return an error.
+func GetXKongComponents(doc v3.Document) (*map[string]interface{}, error) {
+	var components map[string]interface{}
+
+	if doc.Components == nil || doc.Components.Extensions == nil {
+		return &map[string]interface{}{}, nil
+	}
+
+	xKongComponents, ok := doc.Components.Extensions.Get("x-kong")
+
+	if !ok || xKongComponents == nil {
+		return &components, nil
+	}
+
+	xKongComponentsBytes, err := ConvertYamlNodeToBytes(xKongComponents)
+	if err != nil {
+		return nil, fmt.Errorf("expected '/components/x-kong' to be a YAML object")
+	}
+
+	var xKong interface{}
+	_ = yaml.Unmarshal(xKongComponentsBytes, &xKong)
+	components, err = jsonbasics.ToObject(xKong)
+	if err != nil {
+		return nil, fmt.Errorf("expected '/components/x-kong' to be a JSON/YAML object")
+	}
+
+	return &components, nil
+}
+
+// GetXKongObject returns specified 'key' from the extension properties if available.
+// Returns nil if it wasn't found, an error if it wasn't an object or couldn't be
+// dereferenced. The returned object will be json encoded again.
+func GetXKongObject(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	key string, components *map[string]interface{},
+) ([]byte, error) {
+	if extensions == nil {
+		return nil, nil
+	}
+
+	xKongObject, ok := extensions.Get(key)
+	if !ok || xKongObject == nil {
+		return nil, nil
+	}
+
+	xKongObjectBytes, err := ConvertYamlNodeToBytes(xKongObject)
+	if err != nil {
+		return nil, fmt.Errorf("expected '%s' to be a YAML object", key)
+	}
+
+	var jsonBlob interface{}
+	_ = yaml.Unmarshal(xKongObjectBytes, &jsonBlob)
+	jsonObject, err := jsonbasics.ToObject(jsonBlob)
+	if err != nil {
+		return nil, fmt.Errorf("expected '%s' to be a JSON/YAML object", key)
+	}
+
+	object, err := DereferenceJSONObject(jsonObject, components)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(object)
+}
+
+// GetRouteDefaults returns a JSON string containing the route defaults
+func GetRouteDefaults(
+	extensions *orderedmap.Map[string, *yaml.Node],
+	components *map[string]interface{},
+) ([]byte, error) {
+	return GetXKongObject(extensions, "x-kong-route-defaults", components)
 }

--- a/openapitools/utils_test.go
+++ b/openapitools/utils_test.go
@@ -1,6 +1,7 @@
 package openapitools
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,28 @@ func TestCrossProduct(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := CrossProduct(tc.slices...)
 			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func Test_ToKebabCase(t *testing.T) {
+	// Test tool name kebab-case normalization
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"getFlights", "get-flights"},
+		{"get_flights", "get-flights"},
+		{"GetFlights", "get-flights"},
+		{"get-flights", "get-flights"},
+		{"listAllUsers", "list-all-users"},
+		{"CreateNewItem", "create-new-item"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			result := ToKebabCase(tc.input)
+			assert.Equal(t, tc.expected, result, fmt.Sprintf("ToKebabCase(%s)", tc.input))
 		})
 	}
 }

--- a/openapitools/utils_test.go
+++ b/openapitools/utils_test.go
@@ -1,4 +1,4 @@
-package openapi2kong
+package openapitools
 
 import (
 	"testing"
@@ -45,7 +45,7 @@ func TestCrossProduct(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := crossProduct(tc.slices...)
+			result := CrossProduct(tc.slices...)
 			assert.Equal(t, tc.expectedResult, result)
 		})
 	}


### PR DESCRIPTION
## Summary
This PR makes refactoring on top of https://github.com/Kong/go-apiops/pull/286
Refactoring done using gemini, and copilot.

Notable changes include:
1. Use of openapi2kong.Convert inside openapi2mcp before the MCP tools are created - instead of duplication
2. Introduction of openapitools package containing the common code used in openapi2kong, and openapi2mcp
3. Test for kebab case has been moved into openapitools package - utils_test.go

Diff between the two branches in question - https://github.com/Kong/go-apiops/compare/openapi2mcp..feat/openapi2mcp-composition