### PR TITLE
fix: Added a flag to generate header based routes only when needed

### DIFF
--- a/openapi2kong/oas3_testfiles/25-routes-with-headers.expected_skip_header.json
+++ b/openapi2kong/oas3_testfiles/25-routes-with-headers.expected_skip_header.json
@@ -1,0 +1,56 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "server1.com",
+      "id": "0907c4ab-d9e4-5d21-813b-c57a97eeaad9",
+      "name": "simple-api-overview",
+      "path": "/",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "4d47cf34-1c69-5228-acf1-b2c05994bd02",
+          "methods": [
+            "GET"
+          ],
+          "name": "simple-api-overview_get-doc-service",
+          "paths": [
+            "~/path1/(?<pathparam>[^#?/]+)$"
+          ],
+          "plugins": [],
+          "regex_priority": 100,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_25-routes-with-headers.yaml"
+          ]
+        },
+        {
+          "id": "27ea9a0a-216e-5c92-ae0b-8c9aa8493750",
+          "methods": [
+            "GET"
+          ],
+          "name": "simple-api-overview_get-path2-service",
+          "paths": [
+            "~/path2$"
+          ],
+          "plugins": [],
+          "regex_priority": 200,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_25-routes-with-headers.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_25-routes-with-headers.yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}
+

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -52,7 +52,7 @@ type O2kOptions struct {
 	// Generate separate routes for each header enum even if required: false
 	TreatAllHeadersAsRequired bool
 	// Skip generation of separate routes for header parameter enums
-	SkipHeaderRoutes bool
+	SkipRouteByHeader bool
 }
 
 // setDefaults sets the defaults for the OpenAPI2Kong operation.
@@ -1165,7 +1165,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 
 			headerParams := findHeaderParamsForRouting(operation.Parameters, pathitem.Parameters, opts.TreatAllHeadersAsRequired)
 
-			if len(headerParams) > 0 && !opts.SkipHeaderRoutes {
+			if len(headerParams) > 0 && !opts.SkipRouteByHeader {
 				// This operation has header parameters, we need to create different routes based on the header values
 				headerValueCombinations := constructHeaderCombinationsForRouting(headerParams)
 

--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -51,6 +51,8 @@ type O2kOptions struct {
 	IgnoreCircularRefs bool
 	// Generate separate routes for each header enum even if required: false
 	TreatAllHeadersAsRequired bool
+	// Skip generation of separate routes for header parameter enums
+	SkipHeaderRoutes bool
 }
 
 // setDefaults sets the defaults for the OpenAPI2Kong operation.
@@ -1163,7 +1165,7 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 
 			headerParams := findHeaderParamsForRouting(operation.Parameters, pathitem.Parameters, opts.TreatAllHeadersAsRequired)
 
-			if len(headerParams) > 0 {
+			if len(headerParams) > 0 && !opts.SkipHeaderRoutes {
 				// This operation has header parameters, we need to create different routes based on the header values
 				headerValueCombinations := constructHeaderCombinationsForRouting(headerParams)
 

--- a/openapi2kong/openapi2kong_test.go
+++ b/openapi2kong/openapi2kong_test.go
@@ -204,7 +204,7 @@ paths:
 	}
 }
 
-func Test_Openapi2kong_SkipHeaderRoutes(t *testing.T) {
+func Test_Openapi2kong_SkipRouteByHeader(t *testing.T) {
 	suffix := ".expected_skip_header.json"
 	files := findFilesBySuffix(t, fixturePath, suffix)
 
@@ -217,8 +217,8 @@ func Test_Openapi2kong_SkipHeaderRoutes(t *testing.T) {
 
 		dataIn, _ := os.ReadFile(fixturePath + fileNameIn)
 		dataOut, err := Convert(dataIn, O2kOptions{
-			Tags:             []string{"OAS3_import", "OAS3file_" + fileNameIn},
-			SkipHeaderRoutes: true,
+			Tags:              []string{"OAS3_import", "OAS3file_" + fileNameIn},
+			SkipRouteByHeader: true,
 		})
 
 		if err != nil {

--- a/openapi2kong/openapi2kong_test.go
+++ b/openapi2kong/openapi2kong_test.go
@@ -203,3 +203,32 @@ paths:
 		assert.Contains(t, err.Error(), "path-parameter name exceeds 32 characters")
 	}
 }
+
+func Test_Openapi2kong_SkipHeaderRoutes(t *testing.T) {
+	suffix := ".expected_skip_header.json"
+	files := findFilesBySuffix(t, fixturePath, suffix)
+
+	for _, file := range files {
+		fileName := strings.TrimSuffix(file.Name(), suffix)
+
+		fileNameIn := fileName + ".yaml"
+		fileNameExpected := fileName + ".expected_skip_header.json"
+		fileNameOut := fileName + ".generated_skip_header.json"
+
+		dataIn, _ := os.ReadFile(fixturePath + fileNameIn)
+		dataOut, err := Convert(dataIn, O2kOptions{
+			Tags:             []string{"OAS3_import", "OAS3file_" + fileNameIn},
+			SkipHeaderRoutes: true,
+		})
+
+		if err != nil {
+			t.Error(fmt.Sprintf("'%s' didn't expect error: %%w", fixturePath+fileNameIn), err)
+		} else {
+			JSONOut, _ := json.MarshalIndent(dataOut, "", "  ")
+			os.WriteFile(fixturePath+fileNameOut, JSONOut, 0o600)
+			JSONExpected, _ := os.ReadFile(fixturePath + fileNameExpected)
+			assert.JSONEq(t, string(JSONExpected), string(JSONOut),
+				"'%s': the JSON blobs should be equal", fixturePath+fileNameIn)
+		}
+	}
+}


### PR DESCRIPTION
GH: https://github.com/Kong/deck/issues/2037
FTI: https://konghq.atlassian.net/browse/FTI-7492

Summary:
We had added a feature in decK version v1.52.0, where If user has declared header parameters, and their values (in an enum) in the OAS - we started including those in the generated routes.
Recently we got above FTI, where one of the customer, don't want headers to be included in the generated routes.
So we have introduced a new cli flag `skip-header-routes`, to skip headers in the routes.



