### PR TITLE
fix: Updated path param char limit from 32 to 128.

### DIFF
--- a/openapi2kong/openapi2kong.go
+++ b/openapi2kong/openapi2kong.go
@@ -1254,8 +1254,8 @@ func Convert(content []byte, opts O2kOptions) (map[string]interface{}, error) {
 					// match single segment; '/', '?', and '#' can mark the end of a segment
 					// see https://github.com/OAI/OpenAPI-Specification/issues/291#issuecomment-316593913
 					captureName := openapitools.SanitizeRegexCapture(varName, opts.InsoCompat)
-					if len(captureName) >= 32 {
-						return nil, fmt.Errorf("path-parameter name exceeds 32 characters: '%s' (sanitized to '%s')",
+					if len(captureName) >= 128 {
+						return nil, fmt.Errorf("path-parameter name exceeds 128 characters: '%s' (sanitized to '%s')",
 							varName, captureName)
 					}
 					regexMatch := "(?<" + captureName + ">[^#?/]+)"

--- a/openapi2kong/openapi2kong_test.go
+++ b/openapi2kong/openapi2kong_test.go
@@ -179,7 +179,10 @@ func Test_Openapi2kong_IgnoreCircularRefs(t *testing.T) {
 }
 
 func Test_Openapi2kong_pathParamLength(t *testing.T) {
-	testDataString := `
+	// 129 characters, exceeding the 128-character limit
+	longParamName := "something-very-long-that-is-way-beyond-the-previous-32-character-" +
+		"limit-and-now-valid-with-the-updated-128-character-limit-123456"
+	testDataString := fmt.Sprintf(`
 openapi: 3.0.3
 info:
   title: Path parameter test
@@ -188,24 +191,24 @@ servers:
   - url: "https://example.com"
 
 paths:
-  /demo/{something-very-long-that-is-way-beyond-the-32-limit}/:
+  /demo/{%s}/:
     get:
       operationId: opsid
       parameters:
         - in: path
-          name: something-very-long-that-is-way-beyond-the-32-limit
+          name: %s
           required: true
           schema:
             type: string
       responses:
         "200":
           description: OK
-`
+`, longParamName, longParamName)
 	_, err := Convert([]byte(testDataString), O2kOptions{})
 	if err == nil {
 		t.Error("Expected error, but got none")
 	} else {
-		assert.Contains(t, err.Error(), "path-parameter name exceeds 32 characters")
+		assert.Contains(t, err.Error(), "path-parameter name exceeds 128 characters")
 	}
 }
 


### PR DESCRIPTION
FTI: https://konghq.atlassian.net/browse/FTI-7580

Summary:
We encountered an issue where path parameters longer than 32 characters failed to parse. This limitation existed because, prior to Kong Gateway 3.8, regex parsing used PCRE2, which imposed a hardcoded 32-character limit on named capture groups.

Since Kong Gateway has upgraded to PCRE2 version 10.44, and now supports up to 128 characters, and because our minimum supported version will soon be 3.10, we have updated the validation limit from 32 characters to 128 characters.

more details: https://kongstrong.slack.com/archives/C04349E4KRC/p1779388617009859